### PR TITLE
feat: add searchHandler in routes.go, also added main, static styles,…

### DIFF
--- a/implementations/go/backend/database.go
+++ b/implementations/go/backend/database.go
@@ -13,6 +13,9 @@ import (
 // CONFIGURATION: The path to the physical database file used by the application.
 const dbPath = "whoknows.db"
 
+// Global db variabel - kan bruges i alle filer
+var db *sql.DB
+
 // checkDBExists verifies if the database file is physically present on the disk.
 func checkDBExists() bool {
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
@@ -22,7 +25,7 @@ func checkDBExists() bool {
 }
 
 // ConnectDB initiates a connection, checks for file existence, and pings the database.
-func ConnectDB() (*sql.DB, error) {
+func connectDB() (*sql.DB, error) {
 	if !checkDBExists() {
 		fmt.Printf("Critical Error: Database file not found at %s\n", dbPath)
 		os.Exit(1)
@@ -40,15 +43,6 @@ func ConnectDB() (*sql.DB, error) {
 
 	fmt.Println("Connection Status: Successfully connected to whoknows.db")
 	return db, nil
-}
-
-func main() {
-	db, err := ConnectDB()
-	if err != nil {
-		fmt.Printf("Initialization failed: %v\n", err)
-		return
-	}
-	defer db.Close()
 }
 
 func getUserID(db *sql.DB, username string) (int, error) {

--- a/implementations/go/backend/main.go
+++ b/implementations/go/backend/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+    "fmt"
+    "log"
+    "net/http"
+)
+
+func main() {
+    // 1. Forbind til databasen
+		connectDB()
+    // 2. Server static filer (CSS, billeder)
+    http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("../static"))))
+
+    // 3. Page routes
+    http.HandleFunc("/", searchHandler)
+    http.HandleFunc("/about", aboutHandler)
+    http.HandleFunc("/login", loginHandler)
+    http.HandleFunc("/register", registerHandler)
+
+    // 4. Start serveren
+    fmt.Println("Server starter på port 8080...")
+    log.Fatal(http.ListenAndServe(":8080", nil))
+}

--- a/implementations/go/backend/routes.go
+++ b/implementations/go/backend/routes.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+    "html/template"
+    "net/http"
+)
+
+// BaseData indeholder data som alle sider bruger
+type BaseData struct {
+    User  string
+    Flash string
+    Error string
+}
+
+type SearchPageData struct {
+    BaseData
+    SearchResults []Page
+    Query         string
+}
+
+type Page struct {
+    Title    string
+    Content  string
+    Language string
+    URL      string
+}
+
+func searchHandler(w http.ResponseWriter, r *http.Request) {
+    query := r.URL.Query().Get("q")
+    language := r.URL.Query().Get("language")
+
+    if language == "" {
+        language = "en"
+    }
+
+    var searchResults []Page
+
+    if query != "" {
+        rows, err := db.Query(
+            "SELECT title, content, language, url FROM pages WHERE language = ? AND content LIKE ?",
+            language, "%"+query+"%",
+        )
+        if err != nil {
+            http.Error(w, "Database error", http.StatusInternalServerError)
+            return
+        }
+        defer rows.Close()
+
+        for rows.Next() {
+            var page Page
+            if err := rows.Scan(&page.Title, &page.Content, &page.Language, &page.URL); err != nil {
+                http.Error(w, "Scan error", http.StatusInternalServerError)
+                return
+            }
+            searchResults = append(searchResults, page)
+        }
+    }
+
+    tmpl, err := template.ParseFiles(
+        "../templates/layout.html",
+        "../templates/search.html",
+    )
+    if err != nil {
+        http.Error(w, "Template error", http.StatusInternalServerError)
+        return
+    }
+
+    data := SearchPageData{
+        SearchResults: searchResults,
+        Query:         query,
+    }
+
+    tmpl.ExecuteTemplate(w, "layout", data)
+}
+
+func aboutHandler(w http.ResponseWriter, r *http.Request) {
+    tmpl, err := template.ParseFiles(
+        "../templates/layout.html",
+        "../templates/about.html",
+    )
+    if err != nil {
+        http.Error(w, "Template error", http.StatusInternalServerError)
+        return
+    }
+    tmpl.ExecuteTemplate(w, "layout", BaseData{})
+}
+
+func loginHandler(w http.ResponseWriter, r *http.Request) {
+    tmpl, err := template.ParseFiles(
+        "../templates/layout.html",
+        "../templates/login.html",
+    )
+    if err != nil {
+        http.Error(w, "Template error", http.StatusInternalServerError)
+        return
+    }
+    tmpl.ExecuteTemplate(w, "layout", BaseData{})
+}
+
+func registerHandler(w http.ResponseWriter, r *http.Request) {
+    tmpl, err := template.ParseFiles(
+        "../templates/layout.html",
+        "../templates/register.html",
+    )
+    if err != nil {
+        http.Error(w, "Template error", http.StatusInternalServerError)
+        return
+    }
+    tmpl.ExecuteTemplate(w, "layout", BaseData{})
+}


### PR DESCRIPTION
This pull request introduces the initial setup for a Go-based backend web server, establishing the application's main entry point, basic routing, and database connection handling. The changes modularize the backend by separating routing logic and database utilities, and set up handlers for static files and basic web pages.

**Backend initialization and routing:**

* Added a new `main.go` file that initializes the web server, connects to the database using the new `connectDB` function, serves static files, and sets up HTTP handlers for the main page, about, login, and register routes.
* Introduced a new `routes.go` file that defines HTTP handler functions for the search, about, login, and register endpoints, along with supporting data structures for rendering templates.

**Database connection handling:**

* Changed the database connection function from `ConnectDB` to `connectDB`, and moved the global `db` variable declaration to allow shared access across files. The main function now calls `connectDB` instead of handling the database connection inline. [[1]](diffhunk://#diff-739130043d491cefb85672cf88496f06cb9004663bb73343aa77eca5f825b580R16-R18) [[2]](diffhunk://#diff-739130043d491cefb85672cf88496f06cb9004663bb73343aa77eca5f825b580L25-R28)
* Removed the standalone `main` function from `database.go`, as application startup and database connection are now handled in `main.go`.