### PR TITLE
feat: add schema.sql so we can see the changes in the future

### DIFF
--- a/implementations/go/schema.sql
+++ b/implementations/go/schema.sql
@@ -1,0 +1,20 @@
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  username TEXT NOT NULL UNIQUE,
+  email TEXT NOT NULL UNIQUE,
+  password TEXT NOT NULL
+);
+
+-- Default bruger, password er 'password' (MD5 hashed)
+INSERT INTO users (username, email, password) 
+    VALUES ('admin', 'keamonk1@stud.kea.dk', '5f4dcc3b5aa765d61d8327deb882cf99');
+
+CREATE TABLE IF NOT EXISTS pages (
+    title TEXT PRIMARY KEY UNIQUE,
+    url TEXT NOT NULL UNIQUE,
+    language TEXT NOT NULL CHECK(language IN ('en', 'da')) DEFAULT 'en',
+    last_updated TIMESTAMP,
+    content TEXT NOT NULL
+);


### PR DESCRIPTION
This pull request introduces a new database schema for the project, focusing on user management and content pages. The most important changes are the creation of `users` and `pages` tables, along with a default admin user.

Database schema changes:

* Added a `users` table with fields for `id`, `username`, `email`, and `password`, enforcing uniqueness and non-null constraints.
* Inserted a default admin user with a pre-hashed password.
* Added a `pages` table with fields for `title`, `url`, `language`, `last_updated`, and `content`, including constraints for uniqueness and language validation.