### PR TITLE
feat: implement before_request middleware for user context (issue 2.1)

### DIFF
--- a/implementations/go/backend/main.go
+++ b/implementations/go/backend/main.go
@@ -8,22 +8,23 @@ import (
 
 func main() {
     // 1. Forbind til databasen
-		connectDB()
+    connectDB()
+
     // 2. Server static filer (CSS, billeder)
     http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("../static"))))
 
     // 3. Page routes
-    http.HandleFunc("/", searchHandler)
-    http.HandleFunc("/about", aboutHandler)
-    http.HandleFunc("/login", loginHandler)
-    http.HandleFunc("/register", registerHandler)
+    http.HandleFunc("/", WithUser(searchHandler))
+    http.HandleFunc("/about", WithUser(aboutHandler))
+    http.HandleFunc("/login", WithUser(loginHandler))
+    http.HandleFunc("/register", WithUser(registerHandler))
 
     // 4. API routes
-    http.HandleFunc("/api/login", apiLoginHandler)
-		http.HandleFunc("/api/logout", logoutHandler)
-    http.HandleFunc("/api/register", apiRegisterHandler)
+    http.HandleFunc("/api/login", WithUser(apiLoginHandler))
+    http.HandleFunc("/api/logout", WithUser(logoutHandler))
+    http.HandleFunc("/api/register", WithUser(apiRegisterHandler))
 
-    // 4. Start serveren
+    // 5. Start serveren
     fmt.Println("Server starter på port 8080...")
     log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/implementations/go/backend/middleware.go
+++ b/implementations/go/backend/middleware.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+    "context"
+    "net/http"
+)
+
+type contextKey string
+
+const userContextKey contextKey = "user"
+
+func WithUser(next http.HandlerFunc) http.HandlerFunc {
+    return func(w http.ResponseWriter, r *http.Request) {
+        user := getSessionUser(r)
+        ctx := context.WithValue(r.Context(), userContextKey, user)
+        next.ServeHTTP(w, r.WithContext(ctx))
+    }
+}
+
+func getUserFromContext(r *http.Request) string {
+    user, ok := r.Context().Value(userContextKey).(string)
+    if !ok {
+        return ""
+    }
+    return user
+}

--- a/implementations/go/backend/routes.go
+++ b/implementations/go/backend/routes.go
@@ -84,9 +84,9 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
     }
 
     data := SearchPageData{
-        BaseData:      BaseData{User: getSessionUser(r)},
-        SearchResults: searchResults,
-        Query:         query,
+	BaseData:      BaseData{User: getUserFromContext(r)},
+	SearchResults: searchResults,
+	Query:         query,
     }
 
     tmpl.ExecuteTemplate(w, "layout", data)
@@ -101,7 +101,7 @@ func aboutHandler(w http.ResponseWriter, r *http.Request) {
         http.Error(w, "Template error", http.StatusInternalServerError)
         return
     }
-    tmpl.ExecuteTemplate(w, "layout", BaseData{User: getSessionUser(r)})
+    tmpl.ExecuteTemplate(w, "layout", BaseData{User: getUserFromContext(r)})
 }
 
 func loginHandler(w http.ResponseWriter, r *http.Request) {
@@ -113,7 +113,7 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
         http.Error(w, "Template error", http.StatusInternalServerError)
         return
     }
-    tmpl.ExecuteTemplate(w, "layout", BaseData{User: getSessionUser(r)})
+    tmpl.ExecuteTemplate(w, "layout", BaseData{User: getUserFromContext(r)})
 }
 
 func registerHandler(w http.ResponseWriter, r *http.Request) {
@@ -125,7 +125,7 @@ func registerHandler(w http.ResponseWriter, r *http.Request) {
         http.Error(w, "Template error", http.StatusInternalServerError)
         return
     }
-    tmpl.ExecuteTemplate(w, "layout", BaseData{User: getSessionUser(r)})
+    tmpl.ExecuteTemplate(w, "layout", BaseData{User: getUserFromContext(r)})
 }
 
 /*
@@ -145,21 +145,18 @@ func apiLoginHandler(w http.ResponseWriter, r *http.Request) {
     var storedHash string
     err := db.QueryRow("SELECT password FROM users WHERE username = ?", username).Scan(&storedHash)
     if err != nil {
-        // Vis den præcise fejl i terminalen
         fmt.Println("Login fejl:", err)
         tmpl, _ := template.ParseFiles("../templates/layout.html", "../templates/login.html")
         tmpl.ExecuteTemplate(w, "layout", BaseData{Error: err.Error()})
         return
     }
 
-    // Verificer password
     if !verifyPassword(storedHash, password) {
         tmpl, _ := template.ParseFiles("../templates/layout.html", "../templates/login.html")
         tmpl.ExecuteTemplate(w, "layout", BaseData{Error: "Invalid username or password"})
         return
     }
 
-    // Gem session
     session, _ := store.Get(r, "session")
     session.Values["user"] = username
     session.Save(r, w)
@@ -169,7 +166,6 @@ func apiLoginHandler(w http.ResponseWriter, r *http.Request) {
 
 func logoutHandler(w http.ResponseWriter, r *http.Request) {
     session, _ := store.Get(r, "session")
-    // Slet session
     delete(session.Values, "user")
     session.Save(r, w)
     http.Redirect(w, r, "/", http.StatusFound)
@@ -186,7 +182,6 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
     password := r.FormValue("password")
     password2 := r.FormValue("password2")
 
-    // Validering
     if username == "" || email == "" || password == "" {
         tmpl, _ := template.ParseFiles("../templates/layout.html", "../templates/register.html")
         tmpl.ExecuteTemplate(w, "layout", BaseData{Error: "All fields are required"})
@@ -199,7 +194,6 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-    // Tjek om bruger allerede eksisterer
     var exists int
     db.QueryRow("SELECT COUNT(*) FROM users WHERE username = ?", username).Scan(&exists)
     if exists > 0 {
@@ -208,18 +202,15 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
         return
     }
 
-    // Hash password og gem bruger
     hashedPassword := hashPassword(password)
     _, err := db.Exec("INSERT INTO users (username, email, password) VALUES (?, ?, ?)",
         username, email, hashedPassword)
     if err != nil {
-        // Vis den præcise fejl i terminalen
         fmt.Println("Register fejl:", err)
         tmpl, _ := template.ParseFiles("../templates/layout.html", "../templates/register.html")
         tmpl.ExecuteTemplate(w, "layout", BaseData{Error: err.Error()})
         return
     }
 
-    // Register success - redirect til login
     http.Redirect(w, r, "/login", http.StatusFound)
 }


### PR DESCRIPTION
Implement before_request middleware for user context (Issue 2.1)
This PR implements a WithUser middleware in Go, equivalent to Flask's @app.before_request hook.
What was done:

Added middleware.go with WithUser() middleware that runs before every request, fetches the current user from the session, and stores it in the request context — equivalent to g.user in Flask
Updated main.go to wrap all routes with WithUser()
Updated handlers in routes.go to use getUserFromContext(r) instead of calling getSessionUser(r) manually in each handler

Why:
Previously, each handler was responsible for fetching the session user individually. This centralizes that logic in one place, making the code cleaner and easier to maintain.