### PR TITLE
fix: remove internal configuration comments from issue templates body

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.report.md
+++ b/.github/ISSUE_TEMPLATE/bug.report.md
@@ -5,8 +5,6 @@ title: "[BUG][W_INSERT_WEEK] Short description of the problem"
 labels: ["bug", "critical", "backend"]
 ---
 
-<!-- Those --- mark hidden settings that are configuration for GitHub -->
-
 ## Description
 What is the bug? Provide a clear and concise description of the problem.
 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -5,8 +5,6 @@ title: "[W_INSERT_WEEK] Task Name"
 labels: ["backend"]
 ---
 
-<!-- Those --- mark hidden settings that are configuration for GitHub -->
-
 ## Description
 Provide a concise description of the work.
 Does this relate to the Python-to-Go migration?


### PR DESCRIPTION
### Changes Made
Removed internal HTML configuration comments from .github/ISSUE_TEMPLATE/task.md and bug_report.md.


### Why Was It Necessary
During testing of the initial templates, it was discovered that the HTML comments (``) were being rendered inside the issue body. This cluttered the editor for the user and made the templates less "clean" to work with. This fix ensures a better Developer Experience (DX) for the Syntax Squad.


## How to Test
1. Go to the Issues tab on GitHub.
2. Click New Issue and select the "Development Task" template.
3. Verify that the editor field is now clean and only contains the relevant headers (## Description, etc.), without the configuration comments.
4. Repeat for the "Bug Report" template.

## Related Issues
Closes #86 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [ ] My code builds without errors
- [ ] I have tested my changes locally
- [ ] I have updated documentation if needed
