### PR TITLE
ci: update dependabot auto-merge workflow to use PAT for workflow per…

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,4 +21,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN_DEPENDABOT }}


### PR DESCRIPTION
…missions

### Changes Made
Updated the Dependabot auto-merge workflow to use a PAT (PAT_TOKEN_DEPENDABOT) for the merge step instead of GITHUB_TOKEN.



### Why Was It Necessary
GITHUB_TOKEN lacks the `workflows` permission needed to merge Dependabot PRs that update workflow files. This caused the auto-merge step to fail with a GraphQL permission error.


## How to Test
1. Wait for a new Dependabot PR that updates a workflow file
2. Verify the workflow runs without permission errors under Actions
3. Confirm the PR is automatically approved and merged

## Related Issues
<!-- N/A -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
