### PR TITLE
fix: copy migrations folder in docker build and more

### DIFF
--- a/implementations/go/Dockerfile
+++ b/implementations/go/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update \
 WORKDIR /app/backend
 
 COPY --from=build /out/whoknows /app/backend/whoknows
+COPY --from=build /src/implementations/go/migrations /app/migrations
 COPY --from=build /src/implementations/go/templates /app/templates
 COPY --from=build /src/implementations/go/static /app/static
 COPY --from=build /src/implementations/go/schema.sql /app/schema.sql

--- a/implementations/go/backend/migrations.go
+++ b/implementations/go/backend/migrations.go
@@ -16,6 +16,7 @@ func runMigrations() error {
 		"./migrations",
 		"../migrations",
 		"../../migrations",
+		"/app/migrations",
 		"implementations/go/migrations",
 	}
 


### PR DESCRIPTION
### Changes Made

- **Dockerfile**: Added `COPY --from=build /src/implementations/go/migrations /app/migrations` to include migrations folder in runtime stage
- **migrations.go**: Added `/app/migrations` to the list of possible migration directory paths for Docker environment

### Why Was It Necessary

Migrations were not running in the Docker container because:
1. The migrations folder was only copied in the build stage but not carried over to the final runtime stage
2. The migration runner couldn't find the migrations directory (searched paths didn't include `/app/migrations`)
3. Without running migrations, the `password_reset_tokens` table and new user columns (`force_password_reset`, `password_reset_required_at`) were never created
4. This broke the entire forced password reset feature

The warning "migrations directory not found, skipping migrations" was silencing the problem, allowing the app to start but without the necessary database schema for the security feature.

## How to Test

1. **Local Docker build:**
   - Build image: `docker build -f implementations/go/Dockerfile .`
   - Run container: `docker run -e DB_PATH=/tmp/test.db <image>`
   - Verify migrations run: check logs for "✅ Migration executed: 002_add_password_reset.sql"

2. **Production deployment:**
   - Push to `main` branch (triggers CD)
   - Check deployment logs for migration execution
   - Verify database schema: `sudo docker exec whoknows-whoknows-1 sqlite3 /data/whoknows.db "SELECT sql FROM sqlite_master WHERE name='password_reset_tokens';"`
   - Should output CREATE TABLE statement

3. **Functionality test:**
   - Run breach response script: `bash /opt/whoknows/implementations/go/scripts/breach_response.sh`
   - Verify affected users marked: `sudo docker exec whoknows-whoknows-1 sqlite3 /data/whoknows.db "SELECT COUNT(*) FROM users WHERE force_password_reset = 1;"`
   - Should show 20 users
   - Try logging in as affected user → should redirect to password reset page

## Related Issues

Closes: Migrations not running in Docker container - forced password reset feature broken

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist

- [x] My code builds without errors
- [x] I have tested my changes locally
- [x] Docker image builds successfully
- [x] Migrations run on container startup
- [x] password_reset_tokens table created correctly
- [x] Forced password reset feature now works end-to-end
- [x] All 20 affected users can be marked for password reset