### PR TITLE
Fix: Add changes to monitoring so everything works

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ The Go backend now exposes a Prometheus endpoint at:
 
 - `whoknows_http_requests_total{method,path,status}`
 - `whoknows_http_request_duration_seconds{method,path}`
-- `whoknows_login_attempts_total{outcome}`
-- `whoknows_registrations_total{outcome}`
-- `whoknows_searches_total{source,language,query,outcome}`
+- `whoknows_login_attempts_total{outcome}` where `outcome` is `success|failure`
+- `whoknows_registrations_total{outcome}` where `outcome` is `success|validation_error|failure`
+- `whoknows_searches_total{source,language,query,outcome}` where `source` is `web|api` and `outcome` is `success|failure`
 
 `whoknows_searches_total` lets you chart searches for specific terms via the `query` label.
 

--- a/implementations/go/backend/main.go
+++ b/implementations/go/backend/main.go
@@ -35,11 +35,6 @@ func main() {
 		log.Fatalf("Migration failed: %v", err)
 	}
 
-	// 2. Run migrations
-	if err := runMigrations(); err != nil {
-		log.Fatalf("Migration failed: %v", err)
-	}
-
 	// 3. Server static filer (CSS, billeder)
 	http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("../static"))))
 

--- a/implementations/go/backend/metrics.go
+++ b/implementations/go/backend/metrics.go
@@ -2,12 +2,34 @@ package main
 
 import (
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+const (
+	loginOutcomeSuccess = "success"
+	loginOutcomeFailure = "failure"
+
+	registrationOutcomeSuccess         = "success"
+	registrationOutcomeValidationError = "validation_error"
+	registrationOutcomeFailure         = "failure"
+
+	searchOutcomeSuccess = "success"
+	searchOutcomeFailure = "failure"
+)
+
+var (
+	metricsInitOnce sync.Once
+
+	numericSegmentPattern = regexp.MustCompile(`^\d+$`)
+	uuidSegmentPattern    = regexp.MustCompile(`(?i)^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	hexSegmentPattern     = regexp.MustCompile(`(?i)^[0-9a-f]{16,}$`)
 )
 
 var (
@@ -54,13 +76,15 @@ var (
 )
 
 func initMetrics() {
-	prometheus.MustRegister(
-		httpRequestsTotal,
-		httpRequestDurationSeconds,
-		loginAttemptsTotal,
-		registrationsTotal,
-		searchesTotal,
-	)
+	metricsInitOnce.Do(func() {
+		prometheus.MustRegister(
+			httpRequestsTotal,
+			httpRequestDurationSeconds,
+			loginAttemptsTotal,
+			registrationsTotal,
+			searchesTotal,
+		)
+	})
 }
 
 func registerMetricsRoute() {
@@ -68,19 +92,50 @@ func registerMetricsRoute() {
 }
 
 func normalizeMetricPath(path string) string {
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" || trimmedPath == "/" {
+		return "/"
+	}
+
 	if strings.HasPrefix(path, "/static/") {
 		return "/static/*"
 	}
 
-	switch path {
+	switch trimmedPath {
 	case "/", "/about", "/login", "/logout", "/register", "/reset-password":
-		return path
+		return trimmedPath
 	case "/api/search", "/api/login", "/api/logout", "/api/register", "/api/reset-password":
-		return path
+		return trimmedPath
 	case "/metrics":
 		return "/metrics"
 	default:
-		return "/other"
+		segments := strings.Split(strings.Trim(trimmedPath, "/"), "/")
+		for i, segment := range segments {
+			if numericSegmentPattern.MatchString(segment) || uuidSegmentPattern.MatchString(segment) || hexSegmentPattern.MatchString(segment) {
+				segments[i] = "{id}"
+			}
+		}
+		return "/" + strings.Join(segments, "/")
+	}
+}
+
+func normalizeLanguageLabel(language string) string {
+	normalized := strings.ToLower(strings.TrimSpace(language))
+	if normalized == "" {
+		return "unknown"
+	}
+	return normalized
+}
+
+func normalizeSourceLabel(source string) string {
+	normalized := strings.ToLower(strings.TrimSpace(source))
+	switch normalized {
+	case "html", "web":
+		return "web"
+	case "api":
+		return "api"
+	default:
+		return "unknown"
 	}
 }
 
@@ -90,25 +145,47 @@ func normalizeQueryLabel(query string) string {
 		return "_empty"
 	}
 	normalized = strings.Join(strings.Fields(normalized), " ")
-	if len(normalized) > 40 {
-		return normalized[:40] + "..."
+	if len(normalized) > 64 {
+		return normalized[:64] + "..."
 	}
 	return normalized
 }
 
-func recordSearch(source, language, query string, resultCount int, hadError bool) {
+func recordLoginAttempt(outcome string) {
+	if outcome != loginOutcomeSuccess && outcome != loginOutcomeFailure {
+		outcome = loginOutcomeFailure
+	}
+	loginAttemptsTotal.WithLabelValues(outcome).Inc()
+}
+
+func recordRegistrationAttempt(outcome string) {
+	switch outcome {
+	case registrationOutcomeSuccess, registrationOutcomeValidationError, registrationOutcomeFailure:
+		registrationsTotal.WithLabelValues(outcome).Inc()
+	default:
+		registrationsTotal.WithLabelValues(registrationOutcomeFailure).Inc()
+	}
+}
+
+func recordSearch(source, language, query string, hadError bool) {
 	if strings.TrimSpace(query) == "" {
 		return
 	}
 
-	outcome := "empty"
+	outcome := searchOutcomeSuccess
 	if hadError {
-		outcome = "error"
-	} else if resultCount > 0 {
-		outcome = "found"
+		outcome = searchOutcomeFailure
 	}
 
-	searchesTotal.WithLabelValues(source, language, normalizeQueryLabel(query), outcome).Inc()
+	searchesTotal.WithLabelValues(normalizeSourceLabel(source), normalizeLanguageLabel(language), normalizeQueryLabel(query), outcome).Inc()
+}
+
+func resetMetricsForTests() {
+	httpRequestsTotal.Reset()
+	httpRequestDurationSeconds.Reset()
+	loginAttemptsTotal.Reset()
+	registrationsTotal.Reset()
+	searchesTotal.Reset()
 }
 
 type instrumentedResponseWriter struct {

--- a/implementations/go/backend/metrics_test.go
+++ b/implementations/go/backend/metrics_test.go
@@ -1,0 +1,265 @@
+package main
+
+import (
+	"database/sql"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/sessions"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	_ "modernc.org/sqlite"
+)
+
+func setupMetricsTestDB(t *testing.T) {
+	t.Helper()
+
+	var err error
+	db, err = sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open in-memory db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Logf("failed to close db: %v", err)
+		}
+	})
+
+	_, err = db.Exec(`
+		CREATE TABLE users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			username TEXT NOT NULL UNIQUE,
+			email TEXT NOT NULL UNIQUE,
+			password TEXT NOT NULL,
+			force_password_reset BOOLEAN DEFAULT 0
+		);
+
+		CREATE TABLE pages (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			title TEXT NOT NULL UNIQUE,
+			url TEXT NOT NULL UNIQUE,
+			language TEXT NOT NULL DEFAULT 'en',
+			content TEXT NOT NULL
+		);
+
+		CREATE VIRTUAL TABLE pages_fts USING fts5(
+			title,
+			content,
+			language UNINDEXED,
+			url UNINDEXED,
+			content='pages',
+			content_rowid='id'
+		);
+	`)
+	if err != nil {
+		t.Fatalf("failed to create schema: %v", err)
+	}
+}
+
+func setupMetricsTestRuntime(t *testing.T) {
+	t.Helper()
+	initMetrics()
+	resetMetricsForTests()
+	store = sessions.NewCookieStore([]byte("test-secret-key-for-metrics"))
+	if err := os.Setenv("CSRF_RELAXED", "true"); err != nil {
+		t.Fatalf("failed setting CSRF_RELAXED: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Unsetenv("CSRF_RELAXED")
+	})
+}
+
+func TestMetricsEndpointExposesPrometheusFormat(t *testing.T) {
+	setupMetricsTestRuntime(t)
+	httpRequestsTotal.WithLabelValues(http.MethodGet, "/metrics", "200").Inc()
+
+	oldMux := http.DefaultServeMux
+	mux := http.NewServeMux()
+	http.DefaultServeMux = mux
+	t.Cleanup(func() {
+		http.DefaultServeMux = oldMux
+	})
+
+	registerMetricsRoute()
+
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 for /metrics, got %d", rr.Code)
+	}
+
+	body := rr.Body.String()
+	if !strings.Contains(body, "whoknows_http_requests_total") {
+		t.Fatalf("expected whoknows_http_requests_total in metrics output")
+	}
+	if !strings.Contains(body, "process_start_time_seconds") {
+		t.Fatalf("expected process_start_time_seconds in metrics output")
+	}
+}
+
+func TestHTTPMetricsMiddlewareTracksCounterAndHistogramBuckets(t *testing.T) {
+	setupMetricsTestRuntime(t)
+
+	handler := metricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/users/123e4567-e89b-12d3-a456-426614174000", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", rr.Code)
+	}
+
+	counter := testutil.ToFloat64(httpRequestsTotal.WithLabelValues(http.MethodGet, "/users/{id}", "201"))
+	if counter != 1 {
+		t.Fatalf("expected request counter to be 1, got %f", counter)
+	}
+
+	oldMux := http.DefaultServeMux
+	mux := http.NewServeMux()
+	http.DefaultServeMux = mux
+	t.Cleanup(func() {
+		http.DefaultServeMux = oldMux
+	})
+	registerMetricsRoute()
+
+	metricsReq := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	metricsResp := httptest.NewRecorder()
+	mux.ServeHTTP(metricsResp, metricsReq)
+
+	if !strings.Contains(metricsResp.Body.String(), "whoknows_http_request_duration_seconds_bucket") {
+		t.Fatalf("expected histogram bucket metric in /metrics output")
+	}
+}
+
+func TestLoginMetricsSuccessAndFailureIncrementOncePerAttempt(t *testing.T) {
+	setupMetricsTestRuntime(t)
+	setupMetricsTestDB(t)
+
+	hash, err := hashPassword("password123")
+	if err != nil {
+		t.Fatalf("failed hashing password: %v", err)
+	}
+	_, err = db.Exec("INSERT INTO users (username, email, password) VALUES (?, ?, ?)", "loginuser", "login@example.com", hash)
+	if err != nil {
+		t.Fatalf("failed inserting login user: %v", err)
+	}
+
+	failureForm := url.Values{}
+	failureForm.Set("username", "loginuser")
+	failureForm.Set("password", "wrong-password")
+	failureReq := httptest.NewRequest(http.MethodPost, "/api/login", strings.NewReader(failureForm.Encode()))
+	failureReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	failureResp := httptest.NewRecorder()
+	apiLoginHandler(failureResp, failureReq)
+
+	successForm := url.Values{}
+	successForm.Set("username", "loginuser")
+	successForm.Set("password", "password123")
+	successReq := httptest.NewRequest(http.MethodPost, "/api/login", strings.NewReader(successForm.Encode()))
+	successReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	successResp := httptest.NewRecorder()
+	apiLoginHandler(successResp, successReq)
+
+	failureCount := testutil.ToFloat64(loginAttemptsTotal.WithLabelValues(loginOutcomeFailure))
+	if failureCount != 1 {
+		t.Fatalf("expected login failure count 1, got %f", failureCount)
+	}
+
+	successCount := testutil.ToFloat64(loginAttemptsTotal.WithLabelValues(loginOutcomeSuccess))
+	if successCount != 1 {
+		t.Fatalf("expected login success count 1, got %f", successCount)
+	}
+}
+
+func TestRegistrationMetricsOutcomeLabels(t *testing.T) {
+	t.Run("validation_error", func(t *testing.T) {
+		setupMetricsTestRuntime(t)
+		setupMetricsTestDB(t)
+
+		validationForm := url.Values{}
+		validationForm.Set("username", "newuser")
+		validationForm.Set("email", "invalid-email")
+		validationForm.Set("password", "password123")
+		validationForm.Set("password2", "password123")
+		validationReq := httptest.NewRequest(http.MethodPost, "/api/register", strings.NewReader(validationForm.Encode()))
+		validationReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		validationResp := httptest.NewRecorder()
+		apiRegisterHandler(validationResp, validationReq)
+
+		validationCount := testutil.ToFloat64(registrationsTotal.WithLabelValues(registrationOutcomeValidationError))
+		if validationCount != 1 {
+			t.Fatalf("expected validation_error registration count 1, got %f", validationCount)
+		}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		setupMetricsTestRuntime(t)
+		setupMetricsTestDB(t)
+
+		successForm := url.Values{}
+		successForm.Set("username", "okuser")
+		successForm.Set("email", "okuser@example.com")
+		successForm.Set("password", "password123")
+		successForm.Set("password2", "password123")
+		successReq := httptest.NewRequest(http.MethodPost, "/api/register", strings.NewReader(successForm.Encode()))
+		successReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		successResp := httptest.NewRecorder()
+		apiRegisterHandler(successResp, successReq)
+
+		successCount := testutil.ToFloat64(registrationsTotal.WithLabelValues(registrationOutcomeSuccess))
+		if successCount != 1 {
+			t.Fatalf("expected success registration count 1, got %f", successCount)
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		setupMetricsTestRuntime(t)
+		setupMetricsTestDB(t)
+
+		_, err := db.Exec("DROP TABLE users")
+		if err != nil {
+			t.Fatalf("failed dropping users table for failure test: %v", err)
+		}
+
+		failureForm := url.Values{}
+		failureForm.Set("username", "failureuser")
+		failureForm.Set("email", "failure@example.com")
+		failureForm.Set("password", "password123")
+		failureForm.Set("password2", "password123")
+		failureReq := httptest.NewRequest(http.MethodPost, "/api/register", strings.NewReader(failureForm.Encode()))
+		failureReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		failureResp := httptest.NewRecorder()
+		apiRegisterHandler(failureResp, failureReq)
+
+		failureCount := testutil.ToFloat64(registrationsTotal.WithLabelValues(registrationOutcomeFailure))
+		if failureCount != 1 {
+			t.Fatalf("expected failure registration count 1, got %f", failureCount)
+		}
+	})
+}
+
+func TestSearchMetricsNormalizeLabels(t *testing.T) {
+	setupMetricsTestRuntime(t)
+
+	recordSearch("HTML", "EN", "   Fortran   Basics   ", false)
+	recordSearch("api", "DA", "fortran", true)
+
+	successCount := testutil.ToFloat64(searchesTotal.WithLabelValues("web", "en", "fortran basics", searchOutcomeSuccess))
+	if successCount != 1 {
+		t.Fatalf("expected normalized web/en success search count 1, got %f", successCount)
+	}
+
+	failureCount := testutil.ToFloat64(searchesTotal.WithLabelValues("api", "da", "fortran", searchOutcomeFailure))
+	if failureCount != 1 {
+		t.Fatalf("expected api/da failure search count 1, got %f", failureCount)
+	}
+}

--- a/implementations/go/backend/routes.go
+++ b/implementations/go/backend/routes.go
@@ -183,7 +183,7 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 			language, searchQuery,
 		)
 		if err != nil {
-			recordSearch("html", language, query, 0, true)
+			recordSearch("web", language, query, true)
 			http.Error(w, "Database error", http.StatusInternalServerError)
 			return
 		}
@@ -196,14 +196,20 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 		for rows.Next() {
 			var page Page
 			if err := rows.Scan(&page.Title, &page.Content, &page.Language, &page.URL); err != nil {
-				recordSearch("html", language, query, 0, true)
+				recordSearch("web", language, query, true)
 				http.Error(w, "Scan error", http.StatusInternalServerError)
 				return
 			}
 			searchResults = append(searchResults, page)
 		}
 
-		recordSearch("html", language, query, len(searchResults), false)
+		if err := rows.Err(); err != nil {
+			recordSearch("web", language, query, true)
+			http.Error(w, "Scan error", http.StatusInternalServerError)
+			return
+		}
+
+		recordSearch("web", language, query, false)
 	}
 
 	tmpl, err := parseTemplates("layout.html", "search.html")
@@ -304,7 +310,7 @@ func apiSearchHandler(w http.ResponseWriter, r *http.Request) {
 			language, searchQuery,
 		)
 		if err != nil {
-			recordSearch("api", language, query, 0, true)
+			recordSearch("api", language, query, true)
 			http.Error(w, "Database error", http.StatusInternalServerError)
 			return
 		}
@@ -317,14 +323,20 @@ func apiSearchHandler(w http.ResponseWriter, r *http.Request) {
 		for rows.Next() {
 			var page Page
 			if err := rows.Scan(&page.Title, &page.Content, &page.Language, &page.URL); err != nil {
-				recordSearch("api", language, query, 0, true)
+				recordSearch("api", language, query, true)
 				http.Error(w, "Scan error", http.StatusInternalServerError)
 				return
 			}
 			searchResults = append(searchResults, page)
 		}
 
-		recordSearch("api", language, query, len(searchResults), false)
+		if err := rows.Err(); err != nil {
+			recordSearch("api", language, query, true)
+			http.Error(w, "Scan error", http.StatusInternalServerError)
+			return
+		}
+
+		recordSearch("api", language, query, false)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -342,6 +354,11 @@ func apiLoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	outcome := loginOutcomeFailure
+	defer func() {
+		recordLoginAttempt(outcome)
+	}()
+
 	if !requireCSRF(w, r, "/api/login") {
 		return
 	}
@@ -351,10 +368,9 @@ func apiLoginHandler(w http.ResponseWriter, r *http.Request) {
 
 	var storedHash string
 	var userID int
-	var forceReset bool
+	var forceReset int
 	err := db.QueryRow("SELECT id, password, COALESCE(force_password_reset, 0) FROM users WHERE username = ?", username).Scan(&userID, &storedHash, &forceReset)
 	if err != nil {
-		loginAttemptsTotal.WithLabelValues("failure").Inc()
 		tmpl, _ := parseTemplates("layout.html", "login.html")
 		if err := tmpl.ExecuteTemplate(w, "layout", BaseData{Error: "Invalid username or password"}); err != nil {
 			log.Printf("error executing template: %v", err)
@@ -373,7 +389,6 @@ func apiLoginHandler(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 		} else {
-			loginAttemptsTotal.WithLabelValues("failure").Inc()
 			tmpl, _ := parseTemplates("layout.html", "login.html")
 			if err := tmpl.ExecuteTemplate(w, "layout", BaseData{Error: "Invalid username or password"}); err != nil {
 				log.Printf("error executing template: %v", err)
@@ -383,8 +398,7 @@ func apiLoginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// If forced password reset, generate token and redirect
-	if forceReset {
-		loginAttemptsTotal.WithLabelValues("reset_required").Inc()
+	if forceReset == 1 {
 		token, err := generateResetToken(userID)
 		if err != nil {
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
@@ -404,7 +418,7 @@ func apiLoginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	setFlash(w, r, "You were logged in")
-	loginAttemptsTotal.WithLabelValues("success").Inc()
+	outcome = loginOutcomeSuccess
 	http.Redirect(w, r, "/", http.StatusFound)
 }
 
@@ -413,6 +427,11 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, "/register", http.StatusFound)
 		return
 	}
+
+	outcome := registrationOutcomeFailure
+	defer func() {
+		recordRegistrationAttempt(outcome)
+	}()
 
 	if !requireCSRF(w, r, "/api/register") {
 		return
@@ -424,7 +443,7 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
 	password2 := r.FormValue("password2")
 
 	if username == "" {
-		registrationsTotal.WithLabelValues("validation_error").Inc()
+		outcome = registrationOutcomeValidationError
 		tmpl, _ := parseTemplates("layout.html", "register.html")
 		if err := tmpl.ExecuteTemplate(w, "layout", BaseData{Error: "You have to enter a username"}); err != nil {
 			log.Printf("error executing template: %v", err)
@@ -433,7 +452,7 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if email == "" || !strings.Contains(email, "@") {
-		registrationsTotal.WithLabelValues("validation_error").Inc()
+		outcome = registrationOutcomeValidationError
 		tmpl, _ := parseTemplates("layout.html", "register.html")
 		if err := tmpl.ExecuteTemplate(w, "layout", BaseData{Error: "You have to enter a valid email address"}); err != nil {
 			log.Printf("error executing template: %v", err)
@@ -442,7 +461,7 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if len(password) < 8 {
-		registrationsTotal.WithLabelValues("validation_error").Inc()
+		outcome = registrationOutcomeValidationError
 		tmpl, _ := parseTemplates("layout.html", "register.html")
 		if err := tmpl.ExecuteTemplate(w, "layout", BaseData{Error: "Password must be at least 8 characters"}); err != nil {
 			log.Printf("error executing template: %v", err)
@@ -451,7 +470,7 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if password != password2 {
-		registrationsTotal.WithLabelValues("validation_error").Inc()
+		outcome = registrationOutcomeValidationError
 		tmpl, _ := parseTemplates("layout.html", "register.html")
 		if err := tmpl.ExecuteTemplate(w, "layout", BaseData{Error: "The two passwords do not match"}); err != nil {
 			log.Printf("error executing template: %v", err)
@@ -461,13 +480,12 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
 
 	var exists int
 	if err := db.QueryRow("SELECT COUNT(*) FROM users WHERE username = ?", username).Scan(&exists); err != nil {
-		registrationsTotal.WithLabelValues("error").Inc()
 		log.Printf("error checking username existence: %v", err)
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		return
 	}
 	if exists > 0 {
-		registrationsTotal.WithLabelValues("already_exists").Inc()
+		outcome = registrationOutcomeValidationError
 		tmpl, _ := parseTemplates("layout.html", "register.html")
 		if err := tmpl.ExecuteTemplate(w, "layout", BaseData{Error: "The username is already taken"}); err != nil {
 			log.Printf("error executing template: %v", err)
@@ -477,7 +495,6 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
 
 	hashedPassword, err := hashPassword(password)
 	if err != nil {
-		registrationsTotal.WithLabelValues("error").Inc()
 		fmt.Println("Hash error:", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
@@ -486,7 +503,6 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
 	_, err = db.Exec("INSERT INTO users (username, email, password) VALUES (?, ?, ?)",
 		username, email, hashedPassword)
 	if err != nil {
-		registrationsTotal.WithLabelValues("error").Inc()
 		fmt.Println("Register error:", err)
 		tmpl, _ := parseTemplates("layout.html", "register.html")
 		if err := tmpl.ExecuteTemplate(w, "layout", BaseData{Error: "Could not create user"}); err != nil {
@@ -502,7 +518,7 @@ func apiRegisterHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	setFlash(w, r, "You were successfully registered and logged in")
-	registrationsTotal.WithLabelValues("success").Inc()
+	outcome = registrationOutcomeSuccess
 	http.Redirect(w, r, "/", http.StatusFound)
 }
 

--- a/implementations/go/go.mod
+++ b/implementations/go/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect


### PR DESCRIPTION
### Changes Made
Forbedrede og standardiserede Prometheus-metrics i Go-backend til stabile Grafana dashboards.
- Eksponerede/validerede `/metrics` endpoint med `promhttp`.
- Standardiserede HTTP metrics:
  - `whoknows_http_requests_total{method,path,status}`
  - `whoknows_http_request_duration_seconds{method,path}` (med buckets til p95)
- Forbedrede path-normalisering for at undgå høj cardinality.
- Standardiserede login metrics til præcis én increment per login-attempt:
  - `whoknows_login_attempts_total{outcome=success|failure}`
- Standardiserede registration metrics:
  - `whoknows_registrations_total{outcome=success|validation_error|failure}`
- Standardiserede search metrics:
  - `whoknows_searches_total{source,language,query,outcome}`
  - `source` normaliseret til `web|api`
  - `language` normaliseret til lowercase
  - `query` trimmet/sanitiseret og længdebegrænset
  - `outcome` standardiseret til `success|failure`
- Gjorde collector-initialisering robust for tests/re-init (undgår duplicate registration).
- Tilføjede tests for `/metrics`, counters, histogram buckets og label-konsistens.
- Opdaterede README med metric-navne og label/outcome-konventioner.

### Why Was It Necessary
Det var nødvendigt for at sikre korrekte og stabile metrics til monitoring i Prometheus/Grafana, så dashboard-paneler for requests, statuskoder, p95 latency, login/register outcomes, searches og uptime fungerer konsistent uden label-støj eller fejltællinger.

## How to Test
1. Kør tests:
   - `cd implementations/go && go test ./...`
2. Verificér metrics endpoint:
   - `curl -s https://syntax-reborndev.com/metrics | grep whoknows_login_attempts_total`
   - `curl -s https://syntax-reborndev.com/metrics | grep whoknows_registrations_total`
   - `curl -s https://syntax-reborndev.com/metrics | grep whoknows_http_request_duration_seconds_bucket`
3. Verificér PromQL i Prometheus/Grafana:
   - `sum by (outcome) (whoknows_login_attempts_total)`
   - `sum by (outcome) (whoknows_registrations_total)`
   - `histogram_quantile(0.95, sum by (le, path) (rate(whoknows_http_request_duration_seconds_bucket[5m])))`

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [x] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [x] I have updated documentation if needed