### PR TITLE
Update live application URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the **SyntaxDevopsSquad** main repository. This project is part of ou
 
 ## 🌐 Live Application
 
-> **URL:** `<!-- TODO: indsæt domæne her -->`
+> **URL:** `<!-- (https://www.syntax-reborndev.com/) -->`
 
 ---
 


### PR DESCRIPTION
### Changes Made
Update live application URL in README
Replaced the TODO placeholder in README.md with the actual live application URL (https://www.syntax-reborndev.com/).


### Why Was It Necessary
The README had a placeholder comment (<!-- TODO: indsæt domæne her -->) where the live application URL was supposed to go. Now that the domain is live, this updates the README so visitors and reviewers can easily find the application directly from the repo.


## How to Test
1. Go to the repository's README.md on GitHub
2. Find the 🌐 Live Application section
3. Verify that the URL points to https://www.syntax-reborndev.com/ and that the site is reachable

## Related Issues
 N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [x ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
