### PR TITLE
fix(docker): remove migrations COPY since directory no longer exists

### DIFF
--- a/implementations/go/Dockerfile
+++ b/implementations/go/Dockerfile
@@ -6,7 +6,6 @@ COPY implementations/go/go.mod implementations/go/go.sum ./
 RUN go mod download
 
 COPY implementations/go/backend ./backend
-COPY implementations/go/migrations ./migrations
 COPY implementations/go/templates ./templates
 COPY implementations/go/static ./static
 COPY implementations/go/schema.sql ./schema.sql
@@ -22,7 +21,6 @@ RUN apt-get update \
 WORKDIR /app/backend
 
 COPY --from=build /out/whoknows /app/backend/whoknows
-COPY --from=build /src/implementations/go/migrations /app/migrations
 COPY --from=build /src/implementations/go/templates /app/templates
 COPY --from=build /src/implementations/go/static /app/static
 COPY --from=build /src/implementations/go/schema.sql /app/schema.sql


### PR DESCRIPTION
### Changes Made
Removed two COPY instructions for the migrations/ directory from the Dockerfile, as this directory was deleted during the SQLite to PostgreSQL migration.


### Why Was It Necessary
The CD pipeline failed during the Docker build step because the Dockerfile referenced a migrations/ directory that no longer exists in the repository.



## How to Test
1. Push to a PR and verify the Docker build step passes in GitHub Actions
2. Verify the built image starts correctly with docker compose up --build

## Related Issues
Follow-up fix after PR #98 (SQLite → PostgreSQL migration)


## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
