### PR TITLE
fix(cd): restart nginx after deploy and move deploy path from /tmp to…

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,7 +62,7 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           source: docker-compose.prod.yml,implementations/go/scripts/deploy_compose.sh
-          target: /tmp/whoknows-deploy
+          target: /opt/whoknows-deploy
           overwrite: true
 
       - name: Deploy with Docker Compose on VM
@@ -77,8 +77,8 @@ jobs:
             sudo mkdir -p /opt/whoknows
             sudo mkdir -p /opt/whoknows/implementations/go/scripts
 
-            sudo cp -f /tmp/whoknows-deploy/docker-compose.prod.yml /opt/whoknows/docker-compose.prod.yml
-            sudo cp -f /tmp/whoknows-deploy/implementations/go/scripts/deploy_compose.sh /opt/whoknows/implementations/go/scripts/deploy_compose.sh
+            sudo cp -f /opt/whoknows-deploy/docker-compose.prod.yml /opt/whoknows/docker-compose.prod.yml
+            sudo cp -f /opt/whoknows-deploy/implementations/go/scripts/deploy_compose.sh /opt/whoknows/implementations/go/scripts/deploy_compose.sh
 
             cd /opt/whoknows
             sudo mv -f docker-compose.prod.yml docker-compose.yml
@@ -91,5 +91,6 @@ jobs:
             bash /opt/whoknows/implementations/go/scripts/deploy_compose.sh \
               "${{ needs.build-and-push.outputs.image_name }}" \
               "${{ github.sha }}"
-
+            echo "=== Restarting nginx to refresh DNS ==="
+            sudo docker restart tls-nginx-1
             sudo docker image prune -f


### PR DESCRIPTION
### Changes Made
Updated the CD pipeline to restart the nginx reverse proxy after each deploy and moved the deploy staging path from /tmp to /opt for persistence across reboot


### Why Was It Necessary
After the PostgreSQL migration, the production server experienced a 502 Bad Gateway outage lasting ~19 hours. The root cause was nginx caching the old container IP address. Additionally, the deploy staging path was in /tmp which is cleared on reboot, making the setup fragile.


## How to Test
1. Merge a change to main and verify the CD pipeline completes successfully
2. Verify nginx restarts automatically at the end of the deploy step in GitHub Actions logs
3. Verify deploy files are now located in /opt/whoknows-deploy on the VM

## Related Issues
Follow-up fix after the 502 Bad Gateway incident (26-27. april 2026)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [ ] My code builds without errors
- [ ] I have tested my changes locally
- [ ] I have updated documentation if needed
