### PR TITLE
fix(search): support short queries (1-2 chars) using LIKE fallback

### DIFF
--- a/implementations/go/backend/routes.go
+++ b/implementations/go/backend/routes.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"github.com/gorilla/sessions"
@@ -164,11 +165,20 @@ func searchHandler(w http.ResponseWriter, r *http.Request) {
 	var searchResults []Page
 
 	if query != "" {
-		searchQuery := strings.TrimSpace(query) + ":*"
-		rows, err := db.Query(
-			"SELECT title, content, language, url FROM pages WHERE language = $1 AND search_vector @@ to_tsquery('english', $2)",
-			language, searchQuery,
-		)
+		searchQuery := strings.TrimSpace(query)
+		var rows *sql.Rows
+		var err error
+		if len(searchQuery) <= 2 {
+			rows, err = db.Query(
+				"SELECT title, content, language, url FROM pages WHERE language = $1 AND (LOWER(title) LIKE LOWER($2) OR LOWER(content) LIKE LOWER($2))",
+				language, "%"+searchQuery+"%",
+			)
+		} else {
+			rows, err = db.Query(
+				"SELECT title, content, language, url FROM pages WHERE language = $1 AND search_vector @@ to_tsquery('english', $2)",
+				language, searchQuery+":*",
+			)
+		}
 		if err != nil {
 			recordSearch("web", language, query, true)
 			http.Error(w, "Database error", http.StatusInternalServerError)
@@ -289,11 +299,20 @@ func apiSearchHandler(w http.ResponseWriter, r *http.Request) {
 	var searchResults []Page
 
 	if query != "" {
-		searchQuery := strings.TrimSpace(query) + ":*"
-		rows, err := db.Query(
-			"SELECT title, content, language, url FROM pages WHERE language = $1 AND search_vector @@ to_tsquery('english', $2)",
-			language, searchQuery,
-		)
+		searchQuery := strings.TrimSpace(query)
+		var rows *sql.Rows
+		var err error
+		if len(searchQuery) <= 2 {
+			rows, err = db.Query(
+				"SELECT title, content, language, url FROM pages WHERE language = $1 AND (LOWER(title) LIKE LOWER($2) OR LOWER(content) LIKE LOWER($2))",
+				language, "%"+searchQuery+"%",
+			)
+		} else {
+			rows, err = db.Query(
+				"SELECT title, content, language, url FROM pages WHERE language = $1 AND search_vector @@ to_tsquery('english', $2)",
+				language, searchQuery+":*",
+			)
+		}
 		if err != nil {
 			recordSearch("api", language, query, true)
 			http.Error(w, "Database error", http.StatusInternalServerError)


### PR DESCRIPTION
### Changes Made
Updated both searchHandler and apiSearchHandler to support short queries (1-2 characters) using ILIKE fallback. Queries longer than 2 characters continue to use PostgreSQL full-text search with to_tsquery.


### Why Was It Necessary
PostgreSQL's to_tsquery does not support single or double character queries as they are too short to be meaningful tokens. Searching for e.g. "J" or "Go" returned no results even when matching content existed.
How to Test


## How to Test
1.Go to https://syntax-reborndev.com and search for "J" - verify results containing "JavaScript" appear
2. Search for "Go" -  verify relevant results appear
3. Search for "JavaScript" - verify full-text search still works normally for longer queries

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
