### PR TITLE
feat: add terraform setup and neccessary files and updated .gitgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,42 @@ DevOps_backup_*/
 *.log
 *:Zone.Identifier
 implementations/go/whoknows-server
+
+# Created by https://www.toptal.com/developers/gitignore/api/terraform
+# Edit at https://www.toptal.com/developers/gitignore?templates=terraform
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.69.0"
+  constraints = "4.69.0"
+  hashes = [
+    "h1:v3FxvKYMLI4vcIoci76swAvTcxR72gXlvtAaztqra5A=",
+    "zh:2bdbbfea89ad95bc2f620a41aecde5ff32a9406fa7c994028be5486e6d16e8f4",
+    "zh:382971e3b41337ff87eebaa76c070aec6815fcf9c0d29eb4c3049c7a28d5c288",
+    "zh:54d8a2de34b46e68eafcd51afc0a9490817bef4b3b974ebbd7efc8a0953b7eb0",
+    "zh:585f5e61c6d705cc72c337a490c9d02b8862d6543a894cda6fd30b5887b4d8d2",
+    "zh:58d4e9b9fdac72df2add2a4faf4993576f368381e4413c9838d1789fce98b273",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:99ddd3ef3b1cbe9cac517d807c58dfc4c2b54062e920ca2d0f29f219ccfdc987",
+    "zh:9ca1c478dcbe5d45c9a45bb9124dd468cb82747f17c8f3551e7fb28a751a2486",
+    "zh:a221248b5bae9201e20bf6a07adcdb7d9cd045d9285b1e67587e1ae68a2d60c4",
+    "zh:ce10b0354962e9fc67e143cd777b1763216953e9da47777bc7e7861c11e98e53",
+    "zh:d7531ecfcf38f2cb7ea863eb5ec4664086b557dc3c688f04db638f2b628c637d",
+    "zh:f9ca820f0162f4877f37c9144e53dadadd596a45fbc93f2ce926f310e91ac109",
+  ]
+}

--- a/terraform/inline_commands.sh
+++ b/terraform/inline_commands.sh
@@ -1,0 +1,11 @@
+echo "============================================================================================"
+echo "Update packages"
+echo "============================================================================================"
+sudo apt-get update && sudo apt-get install -y software-properties-common
+echo "============================================================================================"
+echo "Install Docker and give user permission"
+echo "============================================================================================"
+sudo apt install -y docker.io
+sudo usermod -aG docker $(whoami)
+sudo systemctl restart docker
+sudo apt install -y docker-compose

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,134 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "=4.69.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+resource "azurerm_resource_group" "whoknows" {
+  name     = "whoknows-rg"
+  location = "Switzerland North"
+}
+
+resource "azurerm_virtual_network" "whoknows" {
+  name                = "whoknows-vnet"
+  resource_group_name = azurerm_resource_group.whoknows.name
+  location            = azurerm_resource_group.whoknows.location
+  address_space       = ["10.0.0.0/16"]
+}
+
+resource "azurerm_subnet" "whoknows" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.whoknows.name
+  virtual_network_name = azurerm_virtual_network.whoknows.name
+  address_prefixes     = ["10.0.2.0/24"]
+}
+
+resource "azurerm_public_ip" "whoknows" {
+  name                = "whoknows-publicip"
+  location            = azurerm_resource_group.whoknows.location
+  resource_group_name = azurerm_resource_group.whoknows.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_network_interface" "whoknows" {
+  name                = "whoknows-nic"
+  location            = azurerm_resource_group.whoknows.location
+  resource_group_name = azurerm_resource_group.whoknows.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.whoknows.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.whoknows.id
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "whoknows" {
+  name                = var.vm_name
+  resource_group_name = azurerm_resource_group.whoknows.name
+  location            = azurerm_resource_group.whoknows.location
+  size                = "Standard_B2ats_v2"
+  admin_username      = "adminuser"
+  network_interface_ids = [
+    azurerm_network_interface.whoknows.id,
+  ]
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
+    version   = "latest"
+  }
+
+  disable_password_authentication = true
+  admin_ssh_key {
+    username   = "adminuser"
+    public_key = file("~/.ssh/id_rsa.pub")
+  }
+  provisioner "remote-exec" {
+    inline = split("\n", templatefile("${path.module}/inline_commands.sh", {}))
+
+    connection {
+      type        = "ssh"
+      user        = "adminuser"
+      private_key = file("~/.ssh/id_rsa")
+      host        = self.public_ip_address
+      timeout     = "2m"
+    }
+  }
+
+}
+
+resource "azurerm_network_security_group" "whoknows_nsg" {
+  name                = "whoknows-nsg"
+  location            = azurerm_resource_group.whoknows.location
+  resource_group_name = azurerm_resource_group.whoknows.name
+
+  security_rule {
+    name                       = "allow-8080"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "8080"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_network_security_rule" "whoknows_ssh_rule" {
+  name                        = "SSH"
+  priority                    = 1000
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = "*"
+  destination_address_prefix  = "*"
+  network_security_group_name = azurerm_network_security_group.whoknows_nsg.name
+  resource_group_name         = azurerm_resource_group.whoknows.name
+}
+
+resource "azurerm_subnet_network_security_group_association" "whoknows_assoc" {
+  subnet_id                 = azurerm_subnet.whoknows.id
+  network_security_group_id = azurerm_network_security_group.whoknows_nsg.id
+}
+
+resource "azurerm_network_interface_security_group_association" "whoknows_nic_assoc" {
+  network_interface_id      = azurerm_network_interface.whoknows.id
+  network_security_group_id = azurerm_network_security_group.whoknows_nsg.id
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,7 @@
+output "public_ip_address" {
+  value = azurerm_public_ip.whoknows.ip_address
+}
+
+output "ssh_command" {
+  value = "ssh ${azurerm_linux_virtual_machine.whoknows.admin_username}@${azurerm_public_ip.whoknows.ip_address}"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,20 @@
+# variables.tf
+variable "db_admin" {
+  description = "PostgreSQL admin brugernavn"
+  type        = string
+}
+
+variable "db_password" {
+  description = "PostgreSQL admin password"
+  type        = string
+  sensitive   = true
+}
+variable "subscription_id" {
+  description = "The azure subscription ID"
+  type        = string
+}
+variable "vm_name" {
+  description = "The name of the virtual machine"
+  type        = string
+  default     = "main-vm"
+}


### PR DESCRIPTION
### Changes Made
Adds Terraform infrastructure-as-code setup for provisioning the WhoKnows application on Azure. Includes configuration for an Azure Linux VM, along with supporting files: `main.tf`, `variables.tf`, `outputs.tf`, `terraform.tfvars`, and a `inline_commands.sh` provisioning script.

### Why Was It Necessary
The team needed a reproducible, version-controlled way to spin up the Azure infrastructure instead of doing it manually through the portal. This ensures consistent environments and makes it easier to rebuild or modify the setup going forward.

## How to Test
1. Copy `.env.example` to `.env` and fill in the required values (or configure `terraform.tfvars`)
2. Run `terraform init` in the `terraform/` directory
3. Run `terraform plan` and verify the planned resources look correct

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed