### PR TITLE
fix: migrate to sonarqube-scan-action v5 (deprecated action)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: SonarSource/sonarcloud-github-action@master
+	uses: SonarSource/sonarqube-scan-action@v5
         with:
           projectBaseDir: .
           args: >

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.24"
           cache: false
       - name: Install dependencies
         run: go mod download all
@@ -56,7 +56,7 @@ jobs:
           fi
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.6
       - name: Run golangci-lint
         run: $(go env GOPATH)/bin/golangci-lint run ./backend/... --timeout=5m
       - name: Build Go application

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: false
       - name: Install dependencies
         run: go mod download all
@@ -56,7 +56,7 @@ jobs:
           fi
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.6
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.0
       - name: Run golangci-lint
         run: $(go env GOPATH)/bin/golangci-lint run ./backend/... --timeout=5m
       - name: Build Go application

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,12 @@ jobs:
             gofmt -s -l backend
             exit 1
           fi
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.12.0
       - name: Run golangci-lint
-        run: $(go env GOPATH)/bin/golangci-lint run ./backend/... --timeout=5m
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.1.6
+          working-directory: implementations/go
+          args: --timeout=5m ./backend/...
       - name: Build Go application
         run: go build -v -o whoknows-server ./backend/...
       - name: Run Go tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v2.1.6
+          version: v2.10.0
           working-directory: implementations/go
           args: --timeout=5m ./backend/...
       - name: Build Go application

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
             exit 1
           fi
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.10.0
           working-directory: implementations/go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
           fi
       - name: Install golangci-lint
         run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.8
       - name: Run golangci-lint
         run: $(go env GOPATH)/bin/golangci-lint run ./backend/... --timeout=5m
       - name: Build Go application

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-	uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v5
         with:
           projectBaseDir: .
           args: >
@@ -80,8 +80,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-    
-
 
   database-validation:
     name: Database Schema Validation


### PR DESCRIPTION
### Changes Made
Migrated SonarCloud GitHub Action from deprecated sonarcloud-github-action@master to sonarqube-scan-action@v7 in ci.yml.


### Why Was It Necessary
The previous action was throwing exit code 3 and a deprecation warning in CI. SonarSource themselves recoomends to use sonarqube-scan-action som drop-in replacement.

How to Test

1. Merge PR and verify that CI pipeline runs green
2. Check that SonarCloud step runs without exit code 3
3. Verify that SonarCloud dashboard updates after merge to main

## Related Issues
Følger op på PR #148

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
