### PR TITLE
fix: pin sonarqube-scan-action to SHA (upgrade v5 → v8.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: SonarCloud Scan
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 #  v8.0.0
         with:
           projectBaseDir: .
           args: >


### PR DESCRIPTION
### Changes Made
Upgraded `sonarqube-scan-action` from `@v5` to `@v8.0.0` with full SHA pin.


### Why Was It Necessary
`@v5` contains a known security vulnerability and uses a deprecated SonarCloud API
endpoint (`/analysis/analyses`) that returns 404, causing the scan to fail entirely.


## How to Test
<!-- Describe how to test your changes -->
1. Push to `main` or open a PR against `main`
2. Check that the `Go Build & Tests` job completes without SonarCloud errors
3. Verify the SonarCloud dashboard receives a new analysis

## Related Issues
pin sonarqube-scan-action to SHA


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
