### PR TITLE
fix: remove sonarcloud CI step, rely on automatic analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,20 +68,6 @@ jobs:
         if: success()
         run: go tool cover -func=coverage.out
 
-      - name: SonarCloud Scan
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 #  v8.0.0
-        with:
-          projectBaseDir: .
-          args: >
-            -Dsonar.projectKey=syntaxdevopssquad-sds_devops-syntaxsquad
-            -Dsonar.organization=syntaxdevopssquad-sds
-            -Dsonar.sources=.
-            -Dsonar.exclusions=**/*_test.go
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-
   database-validation:
     name: Database Schema Validation
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Changes Made
Removed the SonarCloud CI step from the pipeline. SonarCloud now runs
via Automatic Analysis instead.

### Why Was It Necessary
Running both CI analysis and Automatic Analysis simultaneously caused a
conflict where SonarCloud rejected the CI scan with an error. On the
free plan, Automatic Analysis cannot be disabled at project level, so
the CI step was redundant.

SonarCloud still runs on every push — concretely:
1. Code is pushed to GitHub
2. GitHub notifies SonarCloud automatically
3. SonarCloud fetches and analyzes the code
4. Results appear on the SonarCloud dashboard

The CI pipeline handles Go build, tests and linting. SonarCloud handles
code quality analysis. The two run independently.

## How to Test
1. Push to `main` or merge this PR
2. Verify the CI pipeline passes without SonarCloud errors
3. Confirm a new analysis appears on the SonarCloud dashboard

## Related Issues
<!-- Link to any related issues e.g. Closes #123 -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed