### PR TITLE
Feat/infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,21 @@
-# Copy this file to .env and set a real secret before starting Docker Compose.
-# Generate one with: openssl rand -hex 32
+# Copy this file to .env and fill in real values before starting Docker Compose.
+# Generate a secret key with: openssl rand -hex 32
 SECRET_KEY=replace-with-a-long-random-secret
 
 # Optional: relax CSRF checks for black-box simulations that POST directly
 # to /api/login and /api/register without first fetching form tokens.
 # Keep this false in normal/prod operation.
 CSRF_RELAXED=false
+
+# PostgreSQL database credentials
+POSTGRES_DB=whoknows
+POSTGRES_USER=whoknows
+POSTGRES_PASSWORD=replace-with-a-strong-password
+
+# Docker image to deploy (used by docker-compose.prod.yml)
+IMAGE_NAME=ghcr.io/<your-github-org>/whoknows
+IMAGE_TAG=latest
+
+# GitHub Container Registry credentials (needed for pulling private images)
+GHCR_USER=<your-github-username>
+GHCR_PAT=<your-github-personal-access-token-with-read:packages-scope>

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,7 +9,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
-      - /opt/whoknows/postgres-data:/var/lib/postgresql/data
+      - /opt/whoknows/pgdisk/data:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
       interval: 5s

--- a/implementations/go/backend/.env_example
+++ b/implementations/go/backend/.env_example
@@ -1,6 +1,3 @@
 SECRET_KEY=anything
-
 DB_PATH=dbpath/path
-
-# Optional: only set true for controlled simulations/tests.
 CSRF_RELAXED=false

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,8 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.69.0"
   constraints = "4.69.0"
   hashes = [
+    "h1:2n2UFu1Qii2Onxqkm+ZBscFCE+VRIqnQgBEKxixlgq8=",
+    "h1:bdlyhTI3ob4f3g3zPqX8UxN778LqflKBCtJUhCVzK9E=",
     "h1:v3FxvKYMLI4vcIoci76swAvTcxR72gXlvtAaztqra5A=",
     "zh:2bdbbfea89ad95bc2f620a41aecde5ff32a9406fa7c994028be5486e6d16e8f4",
     "zh:382971e3b41337ff87eebaa76c070aec6815fcf9c0d29eb4c3049c7a28d5c288",
@@ -22,9 +24,12 @@ provider "registry.terraform.io/hashicorp/azurerm" {
 }
 
 provider "registry.terraform.io/hashicorp/local" {
-  version = "2.8.0"
+  version     = "2.8.0"
+  constraints = "~> 2.0"
   hashes = [
     "h1:3jWHVwO5QUIS9V1NsK10ZzdpkK2ABuB4G+UIWrVeGp4=",
+    "h1:8z6L2Aa8lbZVxvUbQijo/Xz/5rVCGn5yXEjfSx00WHc=",
+    "h1:KCuj8nPbNP/ofQrAoQIuQ3CP6k+ADpULvxr7dw2PrpM=",
     "zh:05f18164beab4a84753e5fedf463771ee0c6eca8e90346b8766f1e1c186dec1e",
     "zh:563a0702e3711e25ba8930120899b681378b50cbb957fd204b37745c7c9b5f40",
     "zh:5b56ab2ed70ed92721febb4a070af0837f1084c44825c18e4b95f7efb1d45d26",

--- a/terraform/ansible/deploy.sh
+++ b/terraform/ansible/deploy.sh
@@ -8,7 +8,6 @@ terraform apply -auto-approve
 echo "⚙️ Konfigurerer VM med Ansible..."
 cd ansible
 perl -pi -e 's/\r//' inventory.ini
-sleep 30
 ansible-playbook -i inventory.ini playbook.yml
 
 echo "✅ Done!"

--- a/terraform/ansible/playbook.yml
+++ b/terraform/ansible/playbook.yml
@@ -4,6 +4,10 @@
   become: true
 
   tasks:
+    - name: Wait for VM to be ready
+      wait_for_connection:
+        timeout: 120
+
     - name: Update apt cache
       apt:
         update_cache: yes
@@ -28,9 +32,9 @@
       args:
         creates: /usr/bin/docker
 
-    - name: Install docker-compose
+    - name: Install docker-compose-plugin (v2)
       apt:
-        name: docker-compose
+        name: docker-compose-plugin
         state: present
 
     - name: Tilføj adminuser til docker gruppe
@@ -64,3 +68,108 @@
       ufw:
         state: enabled
         policy: deny
+
+    - name: Create postgres disk mount point
+      file:
+        path: /opt/whoknows/pgdisk
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Check if data disk is formatted
+      command: blkid /dev/disk/azure/scsi1/lun10
+      register: blkid_result
+      failed_when: false
+      changed_when: false
+
+    - name: Format data disk (only if not already formatted)
+      filesystem:
+        fstype: ext4
+        dev: /dev/disk/azure/scsi1/lun10
+      when: blkid_result.rc != 0
+
+    - name: Mount data disk
+      mount:
+        path: /opt/whoknows/pgdisk
+        src: /dev/disk/azure/scsi1/lun10
+        fstype: ext4
+        opts: defaults,nofail
+        state: mounted
+
+    - name: Opret postgres data undermappe på disken
+      file:
+        path: /opt/whoknows/pgdisk/data
+        state: directory
+        owner: 999
+        group: 999
+        mode: "0700"
+
+    - name: Opret /opt/whoknows mappe
+      file:
+        path: /opt/whoknows
+        state: directory
+        owner: adminuser
+        group: adminuser
+        mode: "0755"
+
+    - name: Kopiér docker-compose fil til server
+      copy:
+        src: ../../docker-compose.prod.yml
+        dest: /opt/whoknows/docker-compose.yml
+        owner: adminuser
+        group: adminuser
+        mode: "0644"
+
+    - name: Kopiér .env fil til server
+      copy:
+        src: ../../.env
+        dest: /opt/whoknows/.env
+        owner: adminuser
+        group: adminuser
+        mode: "0600"
+
+    - name: Konfigurer Nginx som reverse proxy
+      copy:
+        dest: /etc/nginx/sites-available/whoknows
+        content: |
+          server {
+              listen 80;
+              server_name _;
+
+              location / {
+                  proxy_pass http://localhost:8080;
+                  proxy_set_header Host $host;
+                  proxy_set_header X-Real-IP $remote_addr;
+                  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+              }
+          }
+        mode: "0644"
+
+    - name: Aktiver Nginx site
+      file:
+        src: /etc/nginx/sites-available/whoknows
+        dest: /etc/nginx/sites-enabled/whoknows
+        state: link
+
+    - name: Fjern default Nginx site
+      file:
+        path: /etc/nginx/sites-enabled/default
+        state: absent
+
+    - name: Genstart Nginx
+      service:
+        name: nginx
+        state: restarted
+
+    - name: Log ind på GHCR
+      shell: |
+        source /opt/whoknows/.env
+        echo "$GHCR_PAT" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+      args:
+        executable: /bin/bash
+
+    - name: Start Docker Compose
+      shell: docker compose up -d
+      args:
+        chdir: /opt/whoknows

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,6 +4,17 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "=4.69.0"
     }
+    local = {
+      source  = "hashicorp/local"
+      version = "~> 2.0"
+    }
+  }
+
+  backend "azurerm" {
+    resource_group_name  = "tfstate-rg"
+    storage_account_name = "whoknowstfstate"
+    container_name       = "tfstate"
+    key                  = "whoknows.terraform.tfstate"
   }
 }
 
@@ -14,7 +25,7 @@ provider "azurerm" {
 
 resource "azurerm_resource_group" "whoknows" {
   name     = "whoknows-rg"
-  location = "Switzerland North" # Needs to be changed to a location that supports the VM size you want to use, e.g. "East US"
+  location = "norwayeast"
 }
 
 resource "azurerm_virtual_network" "whoknows" {
@@ -97,6 +108,13 @@ resource "azurerm_network_security_rule" "whoknows_ssh_rule" {
   destination_address_prefix  = "*"
   network_security_group_name = azurerm_network_security_group.whoknows_nsg.name
   resource_group_name         = azurerm_resource_group.whoknows.name
+}
+
+resource "azurerm_virtual_machine_data_disk_attachment" "postgres_data" {
+  managed_disk_id    = "/subscriptions/${var.subscription_id}/resourceGroups/whoknows-data-rg/providers/Microsoft.Compute/disks/whoknows-postgres-data"
+  virtual_machine_id = azurerm_linux_virtual_machine.whoknows.id
+  lun                = 10
+  caching            = "ReadWrite"
 }
 
 resource "azurerm_network_security_rule" "whoknows_8080_rule" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,2 @@
+subscription_id = "00000000-0000-0000-0000-000000000000"
+vm_name         = "example-vm"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,14 +1,4 @@
 # variables.tf
-variable "db_admin" {
-  description = "PostgreSQL admin brugernavn"
-  type        = string
-}
-
-variable "db_password" {
-  description = "PostgreSQL admin password"
-  type        = string
-  sensitive   = true
-}
 variable "subscription_id" {
   description = "The azure subscription ID"
   type        = string


### PR DESCRIPTION
### Changes Made
- Added Azure remote backend for shared Terraform state (Azure Blob Storage)
- Replaced local Postgres volume with persistent Azure Managed Disk in separate resource group (`whoknows-data-rg`)
- Disk is managed outside Terraform via bootstrap script — survives `terraform destroy`
- Added Nginx reverse proxy configuration (port 80 → 8080)
- Added NSG rules for ports 80 and 8080
- Ansible now installs Docker Compose v2 plugin, copies `.env` and `docker-compose.prod.yml`, logs into GHCR and starts containers
- Replaced `sleep 30` with `wait_for_connection` in Ansible
- Removed unused `db_admin` and `db_password` Terraform variables
- Updated `.env.example` with all required variables

### Why Was It Necessary
Infrastructure was not reproducible across team members — Terraform state was local, Postgres data was lost on redeploy, and the VM setup was incomplete (no Nginx proxy, no Docker Compose startup).

## How to Test
1. Run `bash terraform/ansible/deploy.sh` from WSL
2. Visit `http://<public-ip>` — WhoKnows app should be running
3. 
## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed