### PR TITLE
docs: add Service Level Agreement (SLA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Welcome to the **SyntaxDevopsSquad** main repository. This project is part of ou
 - **Infrastructure as Code:** Terraform (Azure VM, network, firewall, DigitalOcean droplet, Cloudflare DNS)
 - **Configuration Management:** Ansible (Docker, Nginx, fail2ban, UFW, swap, disk mount)
 - **DNS:** Cloudflare (automatic A-record update on deploy)
-- **Persistent Storage:** Azure Managed Disk (Postgres data), DigitalOcean Volume (Prometheus data) — both managed outside Terraform lifecycle
+- **Persistent Storage:** Azure Managed Disk (Postgres data), DigitalOcean Volume (Prometheus data) - both managed outside Terraform lifecycle
 - **Remote State:** Terraform state stored in Azure Blob Storage
 - **Server Security:** fail2ban, UFW
 - **Linting:** `golangci-lint`
@@ -55,7 +55,7 @@ Welcome to the **SyntaxDevopsSquad** main repository. This project is part of ou
 ### Monitoring Stack
 - **Metrics:** Prometheus (scrapes `/metrics` on app VM port 8080)
 - **Dashboards:** Grafana (auto-provisioned with datasource + 3 dashboards via Ansible)
-- **Watchdog:** Cron job on monitoring VM — checks `/health` every 5 minutes, auto-restarts app via SSH after 3 consecutive failures
+- **Watchdog:** Cron job on monitoring VM - checks `/health` every 5 minutes, auto-restarts app via SSH after 3 consecutive failures
 - **Deployment:** Separate DigitalOcean VM for resilience (survives Azure app VM destroy)
 
 ### Database Schema
@@ -180,7 +180,7 @@ devops-syntaxsquad/
 - WSL/Linux environment (for Windows users)
 
 **For infrastructure deployment:**
-- Azure CLI (`az`) — authenticated
+- Azure CLI (`az`) - authenticated
 - Terraform
 - Ansible (WSL only)
 - `doctl` (DigitalOcean CLI)
@@ -309,7 +309,7 @@ cd terraform
 terraform destroy -auto-approve
 ```
 
-Postgres and Prometheus data are **not deleted** — they live on persistent disks outside Terraform.
+Postgres and Prometheus data are **not deleted**. They live on persistent disks outside Terraform.
 
 ---
 
@@ -317,7 +317,7 @@ Postgres and Prometheus data are **not deleted** — they live on persistent dis
 
 The Go backend exposes metrics at `GET /metrics` (port 8080) and a health check at `GET /health`.
 
-Prometheus and Grafana run on a separate DigitalOcean VM. Grafana dashboards and the Prometheus datasource are auto-provisioned via Ansible on every deploy — no manual setup required.
+Prometheus and Grafana run on a separate DigitalOcean VM. Grafana dashboards and the Prometheus datasource are auto-provisioned via Ansible on every deploy, no manual setup required.
 
 Live Grafana dashboard: [https://monitor.syntax-reborndev.com/](https://monitor.syntax-reborndev.com/)
 
@@ -334,23 +334,23 @@ Live Grafana dashboard: [https://monitor.syntax-reborndev.com/](https://monitor.
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `whoknows_login_attempts_total` | Counter | `outcome` | Login attempts — `success\|failure` |
-| `whoknows_registrations_total` | Counter | `outcome` | Registrations — `success\|validation_error\|failure` |
-| `whoknows_active_sessions` | Gauge | — | Users currently logged in (fra PostgreSQL sessions-tabel, opdateret hvert 30s) |
-| `whoknows_session_duration_seconds` | Histogram | — | Sessionsvarighed fra login til logout (buckets: 30s–2h) |
+| `whoknows_login_attempts_total` | Counter | `outcome` | Login attempts (`success\|failure`) |
+| `whoknows_registrations_total` | Counter | `outcome` | Registrations (`success\|validation_error\|failure`) |
+| `whoknows_active_sessions` | Gauge | - | Users currently logged in (fra PostgreSQL sessions-tabel, opdateret hvert 30s) |
+| `whoknows_session_duration_seconds` | Histogram | - | Sessionsvarighed fra login til logout (buckets: 30s-2h) |
 
 #### Search
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `whoknows_searches_total` | Counter | `source`, `language`, `query`, `outcome` | Søgninger — `source: web\|api`, `outcome: success\|failure` |
-| `whoknows_search_zero_results_total` | Counter | `language` | Søgninger der returnerede 0 resultater — indikerer content gaps |
+| `whoknows_searches_total` | Counter | `source`, `language`, `query`, `outcome` | Søgninger (`source: web\|api`, `outcome: success\|failure`) |
+| `whoknows_search_zero_results_total` | Counter | `language` | Søgninger der returnerede 0 resultater (indikerer content gaps) |
 
 #### Business
 
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
-| `whoknows_registered_users_total` | Gauge | — | Antal registrerede brugere i databasen (opdateret hvert 30s) |
+| `whoknows_registered_users_total` | Gauge | - | Antal registrerede brugere i databasen (opdateret hvert 30s) |
 
 ### Prometheus Query Examples
 
@@ -389,7 +389,7 @@ The monitoring VM runs a cron job every 5 minutes that checks `GET /health` on t
 
 Automated browser-based simulation is handled by a dedicated tool in a separate repository:
 
-**[whoknows-crawler](https://github.com/SyntaxDevopsSquad-SDS/whoknows-crawler)** – an intelligent Playwright crawler that self-registers bot users and continuously tests endpoints, user flows and response validation against the live application. No manual seeding required – bots find the registration form, create their own accounts and start interacting autonomously.
+**[whoknows-crawler](https://github.com/SyntaxDevopsSquad-SDS/whoknows-crawler)** is an intelligent Playwright crawler that self-registers bot users and continuously tests endpoints, user flows and response validation against the live application. No manual seeding required - bots find the registration form, create their own accounts and start interacting autonomously.
 
 | Bot type | Count | Behaviour |
 |---|---|---|

--- a/docs/SLA.md
+++ b/docs/SLA.md
@@ -1,0 +1,126 @@
+# Service Level Agreement (SLA)
+## WhoKnows — SyntaxSquad
+
+**Version**: 1.0  
+**Effective Date**: May 15, 2026  
+**Provider**: SyntaxSquad (CodeByNajib, AceS0, MarcusLieberH, Daniel23894)  
+**Service URL**: [https://syntax-reborndev.com](https://syntax-reborndev.com)
+
+---
+
+## 1. Service Scope
+
+This SLA covers the **WhoKnows** web application and its supporting infrastructure. The following services are included:
+
+| Component | Description |
+|---|---|
+| **Web Application** | Full-stack Go web app accessible at `https://syntax-reborndev.com` |
+| **Search API** | `GET /api/search` — full-text search over wiki-style pages |
+| **Authentication** | User registration, login, session management, and password reset |
+| **Health Endpoint** | `GET /health` — machine-readable availability check |
+| **Monitoring Dashboard** | Grafana dashboard at `https://monitor.syntax-reborndev.com` |
+
+The following are **excluded** from this SLA:
+- Third-party DNS resolution (Cloudflare, DigitalOcean DNS)
+- Client-side network or device issues
+- Scheduled maintenance windows (announced ≥ 24 hours in advance)
+
+---
+
+## 2. Performance Metrics (SLIs & SLOs)
+
+### 2.1 Availability (Uptime)
+
+| Metric | Target (SLO) | Measurement |
+|---|---|---|
+| Monthly Uptime | **≥ 99.0%** | `100 * avg_over_time(up{job="whoknows-go-backend"}[$__range])` via Prometheus |
+| Health endpoint reachability | `GET /health` returns HTTP 200 | Prometheus scrape every 15 seconds |
+
+**99.0% uptime** allows for a maximum of **~7 hours 18 minutes** of downtime per month.
+
+### 2.2 Response Time
+
+| Endpoint | Target (p95) |
+|---|---|
+| `GET /` — Search page | < 500 ms |
+| `GET /api/search` | < 1000 ms |
+| `POST /login` | < 800 ms |
+| `GET /health` | < 100 ms |
+
+Response time is measured at the server side via `whoknows_http_request_duration_seconds` (Prometheus histogram).
+
+### 2.3 Error Rate
+
+- HTTP 5xx responses: **< 1%** of all requests in any given hour
+
+---
+
+## 3. Response and Resolution Times
+
+| Severity | Definition | Initial Response | Resolution Target |
+|---|---|---|---|
+| **Critical** | Full service unavailability (uptime < 99%) | 1 hour | 4 hours |
+| **High** | Core feature degraded (search/auth broken) | 4 hours | 24 hours |
+| **Medium** | Non-critical feature impacted, workaround exists | 24 hours | 72 hours |
+| **Low** | Minor UI issue or cosmetic bug | 72 hours | Next release |
+
+Incidents are tracked via GitHub Issues on the project repository. Critical incidents trigger automated Grafana alerts via the configured contact points.
+
+---
+
+## 4. Maintenance Windows
+
+- **Scheduled maintenance** will be announced at least **24 hours in advance** via the project GitHub repository.
+- Scheduled downtime does not count toward uptime calculations.
+- Best-effort target: maintenance between **02:00–04:00 CET** on weekdays.
+
+---
+
+## 5. Security Measures
+
+The following protections are in place for the duration of this agreement:
+
+| Measure | Implementation |
+|---|---|
+| **CSRF Protection** | Token-based CSRF middleware on all state-changing endpoints |
+| **Session Security** | Server-side sessions stored in PostgreSQL; signed cookies via `SECRET_KEY` |
+| **Brute-force Protection** | Fail2ban configured on the host server (`server-config/fail2ban-jail.local`) |
+| **Transport Security** | HTTPS enforced via TLS (Caddy reverse proxy) |
+| **Secrets Management** | No secrets committed to version control; `.env` is gitignored |
+| **Breach Response** | Documented and scripted breach response procedure (`scripts/breach_response.sh`) |
+
+Security incidents (e.g. confirmed data breach) will be disclosed to affected users within **72 hours** of discovery.
+
+---
+
+## 6. Compliance Standards
+
+| Standard | Status |
+|---|---|
+| **HTTPS / TLS** | Enforced — plain HTTP redirected to HTTPS |
+| **GDPR (data minimisation)** | Only necessary user data (username, hashed password) is stored |
+| **Password storage** | Passwords are hashed using `bcrypt` — never stored in plaintext |
+| **Dependency management** | Go modules with pinned versions; reviewed via CI pipeline |
+
+---
+
+## 7. Monitoring and Reporting
+
+- Metrics are collected by **Prometheus** (15-second scrape interval) and visualised in **Grafana**.
+- Uptime, request rates, error rates, and session activity are tracked continuously.
+- Historical uptime is available on the monitoring dashboard at [https://monitor.syntax-reborndev.com](https://monitor.syntax-reborndev.com).
+
+---
+
+## 8. Limitations and Exclusions
+
+This SLA does not apply under the following circumstances:
+
+- Force majeure (natural disasters, large-scale cloud provider outages)
+- DDoS attacks exceeding mitigation capacity
+- Breaches caused by compromised user credentials outside our control
+- Downtime during announced maintenance windows
+
+---
+
+*This SLA is provided in good faith as part of an academic DevOps project at EK (2026). It reflects real infrastructure and operational practices.*


### PR DESCRIPTION
## Changes Made
Added `docs/SLA.md` - a Service Level Agreement covering uptime guarantees, response time targets, incident handling, security measures, and compliance for the WhoKnows application.

## Why Was It Necessary
Part of the mandatory DevOps assignment requiring a published SLA. Formalises our 99% uptime commitment backed by existing Prometheus/Grafana monitoring.

## How to Test
1. Open `docs/SLA.md` and verify content is complete
2. Confirm the Prometheus query `100 * avg_over_time(up{job="whoknows-go-backend"}[$__range])` matches the Grafana dashboard panels

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [x] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [x] I have updated documentation if needed