### PR TITLE
feat/weather endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,10 @@ jobs:
         run: |
           go build -o whoknows-server ./backend/...
           ./whoknows-server &
-          sleep 3
+          for i in $(seq 1 15); do
+            curl -sf http://localhost:8080/health && break
+            sleep 2
+          done
       - name: Smoke test /weather
         run: |
           curl -sf http://localhost:8080/weather

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
           done
       - name: Smoke test /weather
         run: |
+          curl -v http://localhost:8080/weather || true
+          curl -v "http://localhost:8080/weather?city=Copenhagen" || true
           curl -sf http://localhost:8080/weather
           curl -sf "http://localhost:8080/weather?city=Copenhagen"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,15 +142,13 @@ jobs:
       - name: Build and start server
         run: |
           go build -o whoknows-server ./backend/...
-          ./whoknows-server &
+          cd backend && ../whoknows-server &
           for i in $(seq 1 15); do
             curl -sf http://localhost:8080/health && break
             sleep 2
           done
       - name: Smoke test /weather
         run: |
-          curl -v http://localhost:8080/weather || true
-          curl -v "http://localhost:8080/weather?city=Copenhagen" || true
           curl -sf http://localhost:8080/weather
           curl -sf "http://localhost:8080/weather?city=Copenhagen"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,60 @@ jobs:
             echo "⚠️ No schema.sql found"
           fi
 
+  weather-smoke-test:
+    name: Weather Endpoint Smoke Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: [go-ci]
+    defaults:
+      run:
+        working-directory: implementations/go
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_DB: whoknows_test
+          POSTGRES_USER: whoknows
+          POSTGRES_PASSWORD: whoknows
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://whoknows:whoknows@localhost:5432/whoknows_test?sslmode=disable
+      SECRET_KEY: test-secret-key-for-ci
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          cache: false
+      - name: Apply schema
+        run: |
+          PGPASSWORD=whoknows psql -h localhost -U whoknows -d whoknows_test -f schema.sql
+      - name: Build and start server
+        run: |
+          go build -o whoknows-server ./backend/...
+          ./whoknows-server &
+          sleep 3
+      - name: Smoke test /weather
+        run: |
+          curl -sf http://localhost:8080/weather
+          curl -sf "http://localhost:8080/weather?city=Copenhagen"
+
+
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs: [go-ci, database-validation]
+    needs: [go-ci, database-validation, weather-smoke-test]
     steps:
       - name: All checks passed
         run: |
@@ -115,4 +163,5 @@ jobs:
           echo "✅ Go build successful"
           echo "✅ Code quality verified"
           echo "✅ Database schema valid"
+          echo "✅ Weather endpoint smoke test passed"
           echo "Ready to merge!"

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Welcome to the **SyntaxDevopsSquad** main repository. This project is part of ou
 - **Security:** CSRF protection, middleware, and breach response tooling
 - **Database:** PostgreSQL with native full-text search
 - **Health Check:** `GET /health` endpoint for uptime monitoring and watchdog integration
+- **Weather Forecast:** `GET /weather` – city-based weather forecast via Open-Meteo API with in-memory cache (10 min TTL)
 
 ### Team Members
 - **CodeByNajib** (NajibGPT)
@@ -103,6 +104,8 @@ devops-syntaxsquad/
 │       │   ├── metrics_test.go
 │       │   ├── security.go
 │       │   ├── security_test.go
+│       │   ├── weather.go
+│       │   ├── weather_test.go
 │       │   └── entrypoint.sh
 │       ├── scripts/
 │       │   ├── deploy.sh
@@ -119,7 +122,8 @@ devops-syntaxsquad/
 │           ├── login.html
 │           ├── register.html
 │           ├── reset-password.html
-│           └── about.html
+│           ├── about.html
+│           └── weather.html
 ├── terraform/
 │   ├── main.tf                          # Azure app VM + Cloudflare DNS
 │   ├── monitoring.tf                    # DigitalOcean monitoring VM + DO Volume attachment
@@ -487,6 +491,7 @@ go test ./...
 - [x] Watchdog auto-recovery via cron + SSH
 - [x] Health endpoint (`/health`)
 - [x] Intelligent browser-based simulation ([whoknows-crawler](https://github.com/SyntaxDevopsSquad-SDS/whoknows-crawler))
+- [x] Weather forecast endpoint (`/weather`) with Open-Meteo integration, per-city caching and smoke test in CI
 
 ---
 

--- a/implementations/go/backend/main.go
+++ b/implementations/go/backend/main.go
@@ -44,6 +44,7 @@ func main() {
 	// 4. Page routes
 	http.HandleFunc("/", searchHandler)
 	http.HandleFunc("/about", aboutHandler)
+	http.HandleFunc("/weather", weatherHandler)
 	http.HandleFunc("/login", loginHandler)
 	http.HandleFunc("/logout", logoutHandler)
 	http.HandleFunc("/register", registerHandler)

--- a/implementations/go/backend/weather.go
+++ b/implementations/go/backend/weather.go
@@ -123,13 +123,13 @@ func getWeatherForCity(city string) (*WeatherData, error) {
 	lat, lon, err := fetchCoordinates(city)
 	if err != nil {
 		log.Printf("fetchCoordinates error for %q: %v", city, err)
-		return nil, fmt.Errorf("City not found")
+		return nil, fmt.Errorf("city not found")
 	}
 
 	wd, err := fetchWeather(lat, lon)
 	if err != nil {
 		log.Printf("fetchWeather error for %q: %v", city, err)
-		return nil, fmt.Errorf("Could not fetch weather data")
+		return nil, fmt.Errorf("could not fetch weather data")
 	}
 
 	wd.City = city

--- a/implementations/go/backend/weather.go
+++ b/implementations/go/backend/weather.go
@@ -110,6 +110,36 @@ func fetchWeather(lat, lon float64) (WeatherData, error) {
 	}, nil
 }
 
+func getWeatherForCity(city string) (*WeatherData, error) {
+	weatherCacheMu.RLock()
+	cached, ok := weatherCache[city]
+	weatherCacheMu.RUnlock()
+
+	if ok && time.Since(cached.fetchedAt) < weatherCacheTTL {
+		wd := cached.data
+		return &wd, nil
+	}
+
+	lat, lon, err := fetchCoordinates(city)
+	if err != nil {
+		log.Printf("fetchCoordinates error for %q: %v", city, err)
+		return nil, fmt.Errorf("City not found")
+	}
+
+	wd, err := fetchWeather(lat, lon)
+	if err != nil {
+		log.Printf("fetchWeather error for %q: %v", city, err)
+		return nil, fmt.Errorf("Could not fetch weather data")
+	}
+
+	wd.City = city
+	weatherCacheMu.Lock()
+	weatherCache[city] = cachedWeather{data: wd, fetchedAt: time.Now()}
+	weatherCacheMu.Unlock()
+
+	return &wd, nil
+}
+
 func weatherHandler(w http.ResponseWriter, r *http.Request) {
 	city := r.URL.Query().Get("city")
 
@@ -119,33 +149,11 @@ func weatherHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if city != "" {
-		weatherCacheMu.RLock()
-		cached, ok := weatherCache[city]
-		weatherCacheMu.RUnlock()
-
-		if ok && time.Since(cached.fetchedAt) < weatherCacheTTL {
-			wd := cached.data
-			data.Weather = &wd
+		wd, err := getWeatherForCity(city)
+		if err != nil {
+			data.Error = err.Error()
 		} else {
-			lat, lon, err := fetchCoordinates(city)
-			if err != nil {
-				log.Printf("fetchCoordinates error for %q: %v", city, err)
-				data.Error = "City not found"
-			} else {
-				wd, err := fetchWeather(lat, lon)
-				if err != nil {
-					log.Printf("fetchWeather error for %q: %v", city, err)
-					data.Error = "Could not fetch weather data"
-				} else {
-					wd.City = city
-
-					weatherCacheMu.Lock()
-					weatherCache[city] = cachedWeather{data: wd, fetchedAt: time.Now()}
-					weatherCacheMu.Unlock()
-
-					data.Weather = &wd
-				}
-			}
+			data.Weather = wd
 		}
 	}
 

--- a/implementations/go/backend/weather.go
+++ b/implementations/go/backend/weather.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+)
+
+var (
+	geocodingBaseURL = "https://geocoding-api.open-meteo.com/v1/search"
+	weatherBaseURL   = "https://api.open-meteo.com/v1/forecast"
+)
+
+type geocodingResponse struct {
+	Results []struct {
+		Name      string  `json:"name"`
+		Latitude  float64 `json:"latitude"`
+		Longitude float64 `json:"longitude"`
+	} `json:"results"`
+}
+
+type openMeteoResponse struct {
+	CurrentWeather struct {
+		Temperature float64 `json:"temperature"`
+		Windspeed   float64 `json:"windspeed"`
+		Weathercode int     `json:"weathercode"`
+	} `json:"current_weather"`
+	Hourly struct {
+		Temperature2m []float64 `json:"temperature_2m"`
+		Weathercode   []int     `json:"weathercode"`
+	} `json:"hourly"`
+}
+
+type WeatherData struct {
+	City        string
+	Temperature float64
+	Windspeed   float64
+	Weathercode int
+}
+
+type cachedWeather struct {
+	data      WeatherData
+	fetchedAt time.Time
+}
+
+const weatherCacheTTL = 10 * time.Minute
+
+var (
+	weatherCache   = make(map[string]cachedWeather)
+	weatherCacheMu sync.RWMutex
+)
+
+type WeatherPageData struct {
+	BaseData
+	Weather *WeatherData
+	City    string
+}
+
+func fetchCoordinates(city string) (float64, float64, error) {
+	reqURL := fmt.Sprintf("%s?name=%s&count=1", geocodingBaseURL, url.QueryEscape(city))
+	resp, err := http.Get(reqURL) //nolint:gosec
+	if err != nil {
+		return 0, 0, fmt.Errorf("geocoding request failed: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("error closing geocoding response body: %v", err)
+		}
+	}()
+
+	var result geocodingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, 0, fmt.Errorf("geocoding decode failed: %w", err)
+	}
+
+	if len(result.Results) == 0 {
+		return 0, 0, fmt.Errorf("city not found: %s", city)
+	}
+
+	r := result.Results[0]
+	return r.Latitude, r.Longitude, nil
+}
+
+func fetchWeather(lat, lon float64) (WeatherData, error) {
+	reqURL := fmt.Sprintf("%s?latitude=%f&longitude=%f&current_weather=true&hourly=temperature_2m,weathercode",
+		weatherBaseURL, lat, lon)
+	resp, err := http.Get(reqURL) //nolint:gosec
+	if err != nil {
+		return WeatherData{}, fmt.Errorf("weather request failed: %w", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("error closing weather response body: %v", err)
+		}
+	}()
+
+	var result openMeteoResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return WeatherData{}, fmt.Errorf("weather decode failed: %w", err)
+	}
+
+	return WeatherData{
+		Temperature: result.CurrentWeather.Temperature,
+		Windspeed:   result.CurrentWeather.Windspeed,
+		Weathercode: result.CurrentWeather.Weathercode,
+	}, nil
+}
+
+func weatherHandler(w http.ResponseWriter, r *http.Request) {
+	city := r.URL.Query().Get("city")
+
+	data := WeatherPageData{
+		BaseData: BaseData{User: getSessionUser(r)},
+		City:     city,
+	}
+
+	if city != "" {
+		weatherCacheMu.RLock()
+		cached, ok := weatherCache[city]
+		weatherCacheMu.RUnlock()
+
+		if ok && time.Since(cached.fetchedAt) < weatherCacheTTL {
+			wd := cached.data
+			data.Weather = &wd
+		} else {
+			lat, lon, err := fetchCoordinates(city)
+			if err != nil {
+				log.Printf("fetchCoordinates error for %q: %v", city, err)
+				data.Error = "City not found"
+			} else {
+				wd, err := fetchWeather(lat, lon)
+				if err != nil {
+					log.Printf("fetchWeather error for %q: %v", city, err)
+					data.Error = "Could not fetch weather data"
+				} else {
+					wd.City = city
+
+					weatherCacheMu.Lock()
+					weatherCache[city] = cachedWeather{data: wd, fetchedAt: time.Now()}
+					weatherCacheMu.Unlock()
+
+					data.Weather = &wd
+				}
+			}
+		}
+	}
+
+	tmpl, err := parseTemplates("layout.html", "weather.html")
+	if err != nil {
+		http.Error(w, "Template error", http.StatusInternalServerError)
+		return
+	}
+	if err := tmpl.ExecuteTemplate(w, "layout", data); err != nil {
+		log.Printf("error executing template: %v", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
+}

--- a/implementations/go/backend/weather_test.go
+++ b/implementations/go/backend/weather_test.go
@@ -20,7 +20,7 @@ func mockGeoServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
+		_, _ = fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
 	}))
 }
 
@@ -28,7 +28,7 @@ func mockWeatherServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(w, `{"current_weather":{"temperature":15.5,"windspeed":10.2,"weathercode":1},"hourly":{"temperature_2m":[15.5],"weathercode":[1]}}`)
+		_, _ = fmt.Fprint(w, `{"current_weather":{"temperature":15.5,"windspeed":10.2,"weathercode":1},"hourly":{"temperature_2m":[15.5],"weathercode":[1]}}`)
 	}))
 }
 
@@ -88,7 +88,7 @@ func TestWeatherHandler(t *testing.T) {
 		geoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callCount++
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
+			_, _ = fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
 		}))
 		defer geoSrv.Close()
 		wxSrv := mockWeatherServer(t)

--- a/implementations/go/backend/weather_test.go
+++ b/implementations/go/backend/weather_test.go
@@ -33,140 +33,147 @@ func mockWeatherServer(t *testing.T) *httptest.Server {
 }
 
 func TestWeatherHandler(t *testing.T) {
-	t.Run("Returns 200 without city param", func(t *testing.T) {
-		setupWeatherTest()
+	t.Run("Returns 200 without city param", testWeatherHandlerNoCityParam)
+	t.Run("Returns 200 with city=Copenhagen", testWeatherHandlerWithCity)
+	t.Run("Cache returns cached data on second call", testWeatherHandlerCacheHit)
+	t.Run("Cache invalidates after TTL", testWeatherHandlerCacheTTL)
+}
 
-		w := httptest.NewRecorder()
-		r := httptest.NewRequest(http.MethodGet, "/weather", nil)
+func testWeatherHandlerNoCityParam(t *testing.T) {
+	t.Helper()
+	setupWeatherTest()
 
-		weatherHandler(w, r)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/weather", nil)
+	weatherHandler(w, r)
 
-		if w.Code != http.StatusOK {
-			t.Errorf("Expected status 200 for weather page without city, got %d", w.Code)
-		}
-		if !strings.Contains(w.Body.String(), "weather") {
-			t.Error("Expected weather page body to contain 'weather'")
-		}
-	})
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200 for weather page without city, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "weather") {
+		t.Error("Expected weather page body to contain 'weather'")
+	}
+}
 
-	t.Run("Returns 200 with city=Copenhagen", func(t *testing.T) {
-		setupWeatherTest()
+func testWeatherHandlerWithCity(t *testing.T) {
+	t.Helper()
+	setupWeatherTest()
 
-		geoSrv := mockGeoServer(t)
-		defer geoSrv.Close()
-		wxSrv := mockWeatherServer(t)
-		defer wxSrv.Close()
+	geoSrv := mockGeoServer(t)
+	defer geoSrv.Close()
+	wxSrv := mockWeatherServer(t)
+	defer wxSrv.Close()
 
-		geocodingBaseURL = geoSrv.URL
-		weatherBaseURL = wxSrv.URL
-		defer func() {
-			geocodingBaseURL = "https://geocoding-api.open-meteo.com/v1/search"
-			weatherBaseURL = "https://api.open-meteo.com/v1/forecast"
-		}()
+	geocodingBaseURL = geoSrv.URL
+	weatherBaseURL = wxSrv.URL
+	defer func() {
+		geocodingBaseURL = "https://geocoding-api.open-meteo.com/v1/search"
+		weatherBaseURL = "https://api.open-meteo.com/v1/forecast"
+	}()
 
-		w := httptest.NewRecorder()
-		r := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
+	weatherHandler(w, r)
 
-		weatherHandler(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status 200 for weather page with city, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "Copenhagen") {
+		t.Errorf("Expected body to contain 'Copenhagen', got: %s", body)
+	}
+	if !strings.Contains(body, "15.5") {
+		t.Errorf("Expected body to contain temperature '15.5', got: %s", body)
+	}
+}
 
-		if w.Code != http.StatusOK {
-			t.Errorf("Expected status 200 for weather page with city, got %d", w.Code)
-		}
-		body := w.Body.String()
-		if !strings.Contains(body, "Copenhagen") {
-			t.Errorf("Expected body to contain 'Copenhagen', got: %s", body)
-		}
-		if !strings.Contains(body, "15.5") {
-			t.Errorf("Expected body to contain temperature '15.5', got: %s", body)
-		}
-	})
+func testWeatherHandlerCacheHit(t *testing.T) {
+	t.Helper()
+	setupWeatherTest()
 
-	t.Run("Cache returns cached data on second call", func(t *testing.T) {
-		setupWeatherTest()
+	callCount := 0
+	geoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
+	}))
+	defer geoSrv.Close()
+	wxSrv := mockWeatherServer(t)
+	defer wxSrv.Close()
 
-		callCount := 0
-		geoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			callCount++
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
-		}))
-		defer geoSrv.Close()
-		wxSrv := mockWeatherServer(t)
-		defer wxSrv.Close()
+	geocodingBaseURL = geoSrv.URL
+	weatherBaseURL = wxSrv.URL
+	defer func() {
+		geocodingBaseURL = "https://geocoding-api.open-meteo.com/v1/search"
+		weatherBaseURL = "https://api.open-meteo.com/v1/forecast"
+	}()
 
-		geocodingBaseURL = geoSrv.URL
-		weatherBaseURL = wxSrv.URL
-		defer func() {
-			geocodingBaseURL = "https://geocoding-api.open-meteo.com/v1/search"
-			weatherBaseURL = "https://api.open-meteo.com/v1/forecast"
-		}()
+	// First request – populates cache
+	w1 := httptest.NewRecorder()
+	r1 := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
+	weatherHandler(w1, r1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("First request: expected 200, got %d", w1.Code)
+	}
 
-		// First request – populates cache
-		w1 := httptest.NewRecorder()
-		r1 := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
-		weatherHandler(w1, r1)
-		if w1.Code != http.StatusOK {
-			t.Fatalf("First request: expected 200, got %d", w1.Code)
-		}
+	// Second request – should hit cache, not the geocoding server
+	w2 := httptest.NewRecorder()
+	r2 := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
+	weatherHandler(w2, r2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("Second request: expected 200, got %d", w2.Code)
+	}
 
-		// Second request – should hit cache, not the geocoding server
-		w2 := httptest.NewRecorder()
-		r2 := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
-		weatherHandler(w2, r2)
-		if w2.Code != http.StatusOK {
-			t.Fatalf("Second request: expected 200, got %d", w2.Code)
-		}
+	if callCount != 1 {
+		t.Errorf("Expected geocoding API to be called once (cache hit on second), got %d calls", callCount)
+	}
+}
 
-		if callCount != 1 {
-			t.Errorf("Expected geocoding API to be called once (cache hit on second), got %d calls", callCount)
-		}
-	})
+func testWeatherHandlerCacheTTL(t *testing.T) {
+	t.Helper()
+	setupWeatherTest()
 
-	t.Run("Cache invalidates after TTL", func(t *testing.T) {
-		setupWeatherTest()
+	// Pre-populate cache with a stale entry
+	weatherCacheMu.Lock()
+	weatherCache["Copenhagen"] = cachedWeather{
+		data:      WeatherData{City: "Copenhagen", Temperature: 99.0},
+		fetchedAt: time.Now().Add(-(weatherCacheTTL + time.Second)),
+	}
+	weatherCacheMu.Unlock()
 
-		// Pre-populate cache with a stale entry
-		weatherCacheMu.Lock()
-		weatherCache["Copenhagen"] = cachedWeather{
-			data:      WeatherData{City: "Copenhagen", Temperature: 99.0},
-			fetchedAt: time.Now().Add(-(weatherCacheTTL + time.Second)),
-		}
-		weatherCacheMu.Unlock()
+	callCount := 0
+	geoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
+	}))
+	defer geoSrv.Close()
+	wxSrv := mockWeatherServer(t)
+	defer wxSrv.Close()
 
-		callCount := 0
-		geoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			callCount++
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
-		}))
-		defer geoSrv.Close()
-		wxSrv := mockWeatherServer(t)
-		defer wxSrv.Close()
+	geocodingBaseURL = geoSrv.URL
+	weatherBaseURL = wxSrv.URL
+	defer func() {
+		geocodingBaseURL = "https://geocoding-api.open-meteo.com/v1/search"
+		weatherBaseURL = "https://api.open-meteo.com/v1/forecast"
+	}()
 
-		geocodingBaseURL = geoSrv.URL
-		weatherBaseURL = wxSrv.URL
-		defer func() {
-			geocodingBaseURL = "https://geocoding-api.open-meteo.com/v1/search"
-			weatherBaseURL = "https://api.open-meteo.com/v1/forecast"
-		}()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
+	weatherHandler(w, r)
 
-		w := httptest.NewRecorder()
-		r := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
-		weatherHandler(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("Expected 200 after cache expiry, got %d", w.Code)
+	}
+	if callCount == 0 {
+		t.Error("Expected geocoding API to be called after cache TTL expired, but it was not")
+	}
 
-		if w.Code != http.StatusOK {
-			t.Fatalf("Expected 200 after cache expiry, got %d", w.Code)
-		}
-		if callCount == 0 {
-			t.Error("Expected geocoding API to be called after cache TTL expired, but it was not")
-		}
-
-		// Verify fresh data replaced the stale 99.0 temperature
-		weatherCacheMu.RLock()
-		updated := weatherCache["Copenhagen"]
-		weatherCacheMu.RUnlock()
-		if updated.data.Temperature == 99.0 {
-			t.Error("Expected cache to be refreshed with new temperature, still has stale value 99.0")
-		}
-	})
+	// Verify fresh data replaced the stale 99.0 temperature
+	weatherCacheMu.RLock()
+	updated := weatherCache["Copenhagen"]
+	weatherCacheMu.RUnlock()
+	if updated.data.Temperature == 99.0 {
+		t.Error("Expected cache to be refreshed with new temperature, still has stale value 99.0")
+	}
 }

--- a/implementations/go/backend/weather_test.go
+++ b/implementations/go/backend/weather_test.go
@@ -137,7 +137,7 @@ func TestWeatherHandler(t *testing.T) {
 		geoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callCount++
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
+			_, _ = fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
 		}))
 		defer geoSrv.Close()
 		wxSrv := mockWeatherServer(t)

--- a/implementations/go/backend/weather_test.go
+++ b/implementations/go/backend/weather_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func setupWeatherTest() {
+	setupRoutesTest()
+	weatherCacheMu.Lock()
+	weatherCache = make(map[string]cachedWeather)
+	weatherCacheMu.Unlock()
+}
+
+func mockGeoServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
+	}))
+}
+
+func mockWeatherServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"current_weather":{"temperature":15.5,"windspeed":10.2,"weathercode":1},"hourly":{"temperature_2m":[15.5],"weathercode":[1]}}`)
+	}))
+}
+
+func TestWeatherHandler(t *testing.T) {
+	t.Run("Returns 200 without city param", func(t *testing.T) {
+		setupWeatherTest()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/weather", nil)
+
+		weatherHandler(w, r)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status 200 for weather page without city, got %d", w.Code)
+		}
+		if !strings.Contains(w.Body.String(), "weather") {
+			t.Error("Expected weather page body to contain 'weather'")
+		}
+	})
+
+	t.Run("Returns 200 with city=Copenhagen", func(t *testing.T) {
+		setupWeatherTest()
+
+		geoSrv := mockGeoServer(t)
+		defer geoSrv.Close()
+		wxSrv := mockWeatherServer(t)
+		defer wxSrv.Close()
+
+		geocodingBaseURL = geoSrv.URL
+		weatherBaseURL = wxSrv.URL
+		defer func() {
+			geocodingBaseURL = "https://geocoding-api.open-meteo.com/v1/search"
+			weatherBaseURL = "https://api.open-meteo.com/v1/forecast"
+		}()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
+
+		weatherHandler(w, r)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("Expected status 200 for weather page with city, got %d", w.Code)
+		}
+		body := w.Body.String()
+		if !strings.Contains(body, "Copenhagen") {
+			t.Errorf("Expected body to contain 'Copenhagen', got: %s", body)
+		}
+		if !strings.Contains(body, "15.5") {
+			t.Errorf("Expected body to contain temperature '15.5', got: %s", body)
+		}
+	})
+
+	t.Run("Cache returns cached data on second call", func(t *testing.T) {
+		setupWeatherTest()
+
+		callCount := 0
+		geoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
+		}))
+		defer geoSrv.Close()
+		wxSrv := mockWeatherServer(t)
+		defer wxSrv.Close()
+
+		geocodingBaseURL = geoSrv.URL
+		weatherBaseURL = wxSrv.URL
+		defer func() {
+			geocodingBaseURL = "https://geocoding-api.open-meteo.com/v1/search"
+			weatherBaseURL = "https://api.open-meteo.com/v1/forecast"
+		}()
+
+		// First request – populates cache
+		w1 := httptest.NewRecorder()
+		r1 := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
+		weatherHandler(w1, r1)
+		if w1.Code != http.StatusOK {
+			t.Fatalf("First request: expected 200, got %d", w1.Code)
+		}
+
+		// Second request – should hit cache, not the geocoding server
+		w2 := httptest.NewRecorder()
+		r2 := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
+		weatherHandler(w2, r2)
+		if w2.Code != http.StatusOK {
+			t.Fatalf("Second request: expected 200, got %d", w2.Code)
+		}
+
+		if callCount != 1 {
+			t.Errorf("Expected geocoding API to be called once (cache hit on second), got %d calls", callCount)
+		}
+	})
+
+	t.Run("Cache invalidates after TTL", func(t *testing.T) {
+		setupWeatherTest()
+
+		// Pre-populate cache with a stale entry
+		weatherCacheMu.Lock()
+		weatherCache["Copenhagen"] = cachedWeather{
+			data:      WeatherData{City: "Copenhagen", Temperature: 99.0},
+			fetchedAt: time.Now().Add(-(weatherCacheTTL + time.Second)),
+		}
+		weatherCacheMu.Unlock()
+
+		callCount := 0
+		geoSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			callCount++
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"results":[{"name":"Copenhagen","latitude":55.6761,"longitude":12.5683}]}`)
+		}))
+		defer geoSrv.Close()
+		wxSrv := mockWeatherServer(t)
+		defer wxSrv.Close()
+
+		geocodingBaseURL = geoSrv.URL
+		weatherBaseURL = wxSrv.URL
+		defer func() {
+			geocodingBaseURL = "https://geocoding-api.open-meteo.com/v1/search"
+			weatherBaseURL = "https://api.open-meteo.com/v1/forecast"
+		}()
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/weather?city=Copenhagen", nil)
+		weatherHandler(w, r)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("Expected 200 after cache expiry, got %d", w.Code)
+		}
+		if callCount == 0 {
+			t.Error("Expected geocoding API to be called after cache TTL expired, but it was not")
+		}
+
+		// Verify fresh data replaced the stale 99.0 temperature
+		weatherCacheMu.RLock()
+		updated := weatherCache["Copenhagen"]
+		weatherCacheMu.RUnlock()
+		if updated.data.Temperature == 99.0 {
+			t.Error("Expected cache to be refreshed with new temperature, still has stale value 99.0")
+		}
+	})
+}

--- a/implementations/go/templates/weather.html
+++ b/implementations/go/templates/weather.html
@@ -1,0 +1,22 @@
+{{ define "content" }}
+<h1>Weather</h1>
+
+<form action="/weather" method="GET">
+    <label for="city-input">City:</label>
+    <input type="text" id="city-input" name="city" value="{{ .City }}" placeholder="Enter city name...">
+    <button type="submit">Get Weather</button>
+</form>
+
+{{ if .Error }}
+<div class="error"><strong>Error:</strong> {{ .Error }}</div>
+{{ end }}
+
+{{ if .Weather }}
+<div id="weather-result">
+    <h2>{{ .Weather.City }}</h2>
+    <p>Temperature: {{ .Weather.Temperature }} &deg;C</p>
+    <p>Wind speed: {{ .Weather.Windspeed }} km/h</p>
+    <p>Weather code: {{ .Weather.Weathercode }}</p>
+</div>
+{{ end }}
+{{ end }}


### PR DESCRIPTION
### Changes Made
Adds a `/weather` endpoint that displays city-based weather forecasts by integrating with the Open-Meteo API. Includes an in-memory cache per city with a 10-minute TTL to limit external API calls, a new `weather.html` template, unit tests and a CI smoke test job.
Updated README.md with the new `/weather` endpoint under Core Functionality, project structure and Week 8+ milestones.

### Why Was It Necessary
Required by the consumer report assignment. Consumers have become highly interested in weather forecasts, and this is an opportunity to integrate with a 3rd party service and test the integration as part of our CI pipeline.

## How to Test
1. Run the app locally: `docker compose up`
2. Navigate to `http://localhost:8080/weather`
3. Search for a city e.g. `Copenhagen` and verify the forecast is displayed
4. Search for the same city again within 10 minutes and verify the cache is used (no new API call in logs)

## Related Issues
N/A

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [x] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [x] I have updated documentation if needed
