### PR TITLE
# feat: add weather nav button + fix prometheus job name

### DIFF
--- a/implementations/go/static/style.css
+++ b/implementations/go/static/style.css
@@ -138,6 +138,26 @@ nav a:hover {
     color: #372a9f;
 }
 
+#nav-weather {
+    padding: 6px 12px;
+    border-radius: 999px;
+    border: 1px solid #d7cdfd;
+    background: #f4f1ff;
+    color: #4b3fb8;
+    font-size: 0.92rem;
+}
+
+#nav-weather:hover {
+    background: #ebe5ff;
+    color: #3f32ab;
+}
+
+#nav-weather:active,
+#nav-weather.is-active {
+    background: #e0d7ff;
+    color: #372a9f;
+}
+
 #nav-login.is-active,
 #nav-register.is-active,
 #nav-logout {

--- a/implementations/go/templates/layout.html
+++ b/implementations/go/templates/layout.html
@@ -13,6 +13,7 @@
     <div class="navigation">
     <nav>
         <h1><a id="nav-logo" href="/search">¿Who Knows?</a></h1>
+        <a id="nav-weather" href="/weather">Weather</a>
         {{ if .User }}
         <a id="nav-logout" href="/logout">Log out [{{ .User }}]</a>
         {{ else }}
@@ -39,6 +40,13 @@
         const path = window.location.pathname;
         const loginLink = document.getElementById("nav-login");
         const registerLink = document.getElementById("nav-register");
+
+        const weatherLink = document.getElementById("nav-weather");
+
+        if (weatherLink && path === "/weather") {
+            weatherLink.classList.add("is-active");
+            weatherLink.setAttribute("aria-current", "page");
+        }
 
         if (loginLink && path === "/login") {
             loginLink.classList.add("is-active");

--- a/terraform/ansible/monitoring-playbook.yml
+++ b/terraform/ansible/monitoring-playbook.yml
@@ -143,7 +143,7 @@
             evaluation_interval: 15s
 
           scrape_configs:
-            - job_name: 'whoknows-app'
+            - job_name: 'whoknows-go-backend'
               static_configs:
                 - targets: ['{{ app_ip }}:8080']
               metrics_path: '/metrics'


### PR DESCRIPTION
### Changes Made
- Tilføjet "Weather" navigationsknap i nav-baren med pill-styling (samme stil som Login/Register)
- Rettet Prometheus `job_name` fra `whoknows-app` til `whoknows-go-backend`

### Why Was It Necessary
Weather-siden eksisterede som endpoint (`/weather`) men havde ingen direkte adgang fra navigationen. Prometheus job-navnet matchede ikke det faktiske backend-navn.

## How to Test
1. Start applikationen og gå til forsiden
2. Verificér at "Weather"-knappen er synlig i nav-baren
3. Klik på knappen og bekræft at `/weather` loades korrekt

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [x] New feature

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed