### PR TITLE
fix/weather stale cache fallback

### DIFF
--- a/implementations/go/backend/weather.go
+++ b/implementations/go/backend/weather.go
@@ -40,6 +40,7 @@ type WeatherData struct {
 	Temperature float64
 	Windspeed   float64
 	Weathercode int
+	Stale       bool
 }
 
 type cachedWeather struct {
@@ -123,12 +124,22 @@ func getWeatherForCity(city string) (*WeatherData, error) {
 	lat, lon, err := fetchCoordinates(city)
 	if err != nil {
 		log.Printf("fetchCoordinates error for %q: %v", city, err)
+		if ok {
+			stale := cached.data
+			stale.Stale = true
+			return &stale, nil
+		}
 		return nil, fmt.Errorf("city not found")
 	}
 
 	wd, err := fetchWeather(lat, lon)
 	if err != nil {
 		log.Printf("fetchWeather error for %q: %v", city, err)
+		if ok {
+			stale := cached.data
+			stale.Stale = true
+			return &stale, nil
+		}
 		return nil, fmt.Errorf("could not fetch weather data")
 	}
 

--- a/implementations/go/templates/weather.html
+++ b/implementations/go/templates/weather.html
@@ -17,6 +17,9 @@
     <p>Temperature: {{ .Weather.Temperature }} &deg;C</p>
     <p>Wind speed: {{ .Weather.Windspeed }} km/h</p>
     <p>Weather code: {{ .Weather.Weathercode }}</p>
+    {{if .Weather.Stale}}
+    <p><em>⚠️ Weather data may be outdated – service temporarily unavailable.</em></p>
+    {{end}}
 </div>
 {{ end }}
 {{ end }}


### PR DESCRIPTION
### Changes Made
Implements a stale cache fallback in the weather endpoint. When Open-Meteo is unavailable (504 or connection error), the handler now returns the last cached weather data for the city instead of showing an error. A warning message is displayed to the user when stale data is being served.

### Why Was It Necessary
Open-Meteo experienced a 504 Gateway Timeout in production, causing the `/weather` endpoint to show "could not fetch weather data" for all cities. Since we cache results per city, we can serve slightly outdated data gracefully rather than failing completely.

## How to Test
1. Search for a city to populate the cache e.g. `Copenhagen`
2. Simulate an outage by temporarily pointing `weatherBaseURL` to an invalid URL
3. Search for the same city again – verify stale data is shown with the warning message

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed