### PR TITLE
fix: increase weather cache TTL from 10 minutes to 1 hour

### DIFF
--- a/implementations/go/backend/weather.go
+++ b/implementations/go/backend/weather.go
@@ -48,7 +48,7 @@ type cachedWeather struct {
 	fetchedAt time.Time
 }
 
-const weatherCacheTTL = 10 * time.Minute
+const weatherCacheTTL = 1 * time.Hour
 
 var (
 	weatherCache   = make(map[string]cachedWeather)


### PR DESCRIPTION
### Changes Made
Increased the weather cache TTL from 10 minutes to 1 hour in `weather.go`.

### Why Was It Necessary
Open-Meteo has experienced repeated 504 Gateway Timeouts in production. With a 10-minute TTL, the cache expires frequently and leaves users with no fallback data when the API is unavailable. A 1-hour TTL means cached weather data survives longer outages, reducing the number of failed requests.

## How to Test
1. Search for a city on `/weather` to populate the cache
2. Verify the cached data is served for up to 1 hour without a new API call
3. Confirm the stale cache fallback still works when Open-Meteo is unavailable

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [ ] I have updated documentation if needed