### PR TITLE
fix: Prometheus scraping, smoke test URL, and session tracking fixes

### DIFF
--- a/terraform/ansible/deploy.sh
+++ b/terraform/ansible/deploy.sh
@@ -21,7 +21,8 @@ echo ""
 echo "⚙️  Konfigurerer app VM med Ansible..."
 cd ansible
 perl -pi -e 's/\r//' inventory.ini
-ansible-playbook -i inventory.ini playbook.yml
+ansible-playbook -i inventory.ini playbook.yml \
+  -e "monitoring_ip=$MONITORING_IP"
 
 echo ""
 echo "📊 Konfigurerer monitoring VM med Ansible..."

--- a/terraform/ansible/monitoring-playbook.yml
+++ b/terraform/ansible/monitoring-playbook.yml
@@ -152,7 +152,7 @@
           scrape_configs:
             - job_name: 'whoknows-go-backend'
               static_configs:
-                - targets: ['{{ app_ip }}:8080']
+                - targets: ['{{ app_ip }}:80']
               metrics_path: '/metrics'
 
     # ─── Grafana provisioning (datasource + dashboards) ────────────────────────

--- a/terraform/ansible/playbook.yml
+++ b/terraform/ansible/playbook.yml
@@ -237,7 +237,16 @@
           server {
               listen 80;
               server_name syntax-reborndev.com www.syntax-reborndev.com;
-              return 301 https://$host$request_uri;
+
+              location /metrics {
+                  allow {{ monitoring_ip }};
+                  deny all;
+                  proxy_pass http://localhost:8080/metrics;
+              }
+
+              location / {
+                  return 301 https://$host$request_uri;
+              }
           }
         mode: "0644"
 


### PR DESCRIPTION
### Changes Made
- Fixed Prometheus scraping by exposing `/metrics` via nginx port 80 (restricted to monitoring server IP only), port 8080 is now localhost-only
- Updated smoke test URL from direct `ip:8080` to `https://syntax-reborndev.com` via nginx
- Fixed `deploy.sh` to pass `monitoring_ip` to app playbook so nginx knows which IP to whitelist
- Updated Prometheus scrape target from `:8080` to `:80`

### Why Was It Necessary
After binding port 8080 to `127.0.0.1` (security fix), Prometheus on the monitoring server could no longer scrape metrics externally, causing "No data" in all Grafana dashboards. The smoke test was also hitting port 8080 directly, which broke after the same change.

## How to Test
1. Re-run `deploy.sh` from WSL, Prometheus should start scraping via port 80
2. Open Grafana, all dashboards should show live data within 30 seconds
3. Trigger CD pipeline, smoke test should pass

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] CI/CD / Infrastructure
- [ ] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [x] I have updated documentation if needed