### PR TITLE
fix: correct alert job name and update README accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,25 +42,26 @@ Welcome to the **SyntaxDevopsSquad** main repository. This project is part of ou
 - **Language:** Go 1.25.0
 - **Database:** PostgreSQL 16 with `github.com/lib/pq`
 - **Session Management:** Gorilla Sessions
+- **Logging:** Structured JSON logging via `log/slog`
 
 ### Infrastructure & DevOps
 - **Cloud Platforms:** Azure (app VM) + DigitalOcean (monitoring VM)
 - **Containerization:** Docker + Docker Compose (dev & prod)
-- **CI/CD:** GitHub Actions (`ci.yml`, `cd.yml`, `dependabot-auto-merge.yml`)
+- **CI/CD:** GitHub Actions (`ci.yml`, `cd.yml`, `dependabot-auto-merge.yml`) — CI includes Hadolint (Dockerfile linting), CD includes Trivy (image vulnerability scanning). All actions SHA-pinned.
 - **Infrastructure as Code:** Terraform (Azure VM, network, firewall, DigitalOcean droplet, Cloudflare DNS)
 - **Configuration Management:** Ansible (Docker, Nginx, fail2ban, UFW, swap, disk mount)
 - **DNS:** Cloudflare (automatic A-record update on deploy)
 - **Persistent Storage:** Azure Managed Disk (Postgres data), DigitalOcean Volume (Prometheus data) - both managed outside Terraform lifecycle
 - **Remote State:** Terraform state stored in Azure Blob Storage
-- **Server Security:** fail2ban, UFW
+- **Server Security:** fail2ban, UFW, port 8080 bound to `127.0.0.1` (nginx-only access)
 - **Linting:** `golangci-lint`
 - **Code Quality:** SonarCloud (Automatic Analysis)
 - **Version Control:** Git with Conventional Commits
 - **Development Environment:** WSL (Ubuntu 22.04)
 
 ### Monitoring Stack
-- **Metrics:** Prometheus (scrapes `/metrics` via nginx port 80, restricted to monitoring VM IP)
-- **Dashboards:** Grafana (auto-provisioned with datasource + 3 dashboards via Ansible)
+- **Metrics:** Prometheus (scrapes `/metrics` via nginx on app VM port 80, restricted to monitoring VM IP)
+- **Dashboards:** Grafana (auto-provisioned with datasource + 4 dashboards via Ansible: auth, business, requests, overview)
 - **Watchdog:** Cron job on monitoring VM - checks `/health` every 5 minutes, auto-restarts app via SSH after 3 consecutive failures
 - **Deployment:** Separate DigitalOcean VM for resilience (survives Azure app VM destroy)
 
@@ -327,7 +328,7 @@ Postgres and Prometheus data are **not deleted**. They live on persistent disks 
 
 ## Monitoring (Prometheus + Grafana)
 
-The Go backend exposes metrics at `GET /metrics` (port 8080) and a health check at `GET /health`.
+The Go backend exposes metrics at `GET /metrics` (served via nginx port 80, restricted to monitoring VM IP) and a health check at `GET /health`.
 
 Prometheus and Grafana run on a separate DigitalOcean VM. Grafana dashboards and the Prometheus datasource are auto-provisioned via Ansible on every deploy, no manual setup required.
 
@@ -432,7 +433,7 @@ We follow **Conventional Commits** for clean and readable history:
 
 ### Branch Strategy
 
-See [`docs/mandatory/BRANCHING_STRATEGY.md`](docs/mandatory/BRANCHING_STRATEGY.md) for the full strategy.
+See [`docs/mandatory/mandatory-I/BRANCHING_STRATEGY.md`](docs/mandatory/mandatory-I/BRANCHING_STRATEGY.md) for the full strategy.
 
 We follow **GitHub Flow**:
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Welcome to the **SyntaxDevopsSquad** main repository. This project is part of ou
 - **Development Environment:** WSL (Ubuntu 22.04)
 
 ### Monitoring Stack
-- **Metrics:** Prometheus (scrapes `/metrics` on app VM port 8080)
+- **Metrics:** Prometheus (scrapes `/metrics` via nginx port 80, restricted to monitoring VM IP)
 - **Dashboards:** Grafana (auto-provisioned with datasource + 3 dashboards via Ansible)
 - **Watchdog:** Cron job on monitoring VM - checks `/health` every 5 minutes, auto-restarts app via SSH after 3 consecutive failures
 - **Deployment:** Separate DigitalOcean VM for resilience (survives Azure app VM destroy)
@@ -82,14 +82,17 @@ devops-syntaxsquad/
 ├── docs/
 │   ├── pipeline-overview.puml           # DevOps lifecycle diagram (PlantUML source)
 │   ├── Pipeline.png                     # Rendered pipeline diagram
-│   ├── openapi.yaml                     # API specification
+│   ├── SLA.md                           # Service Level Agreement
+│   ├── monitoring_repo_prompt.md
 │   └── mandatory/
-│       ├── BRANCHING_STRATEGY.md        # Git branching documentation
-│       ├── dependency_graph.dot         # System architecture (Graphviz source)
-│       ├── dependency_graph_picture.svg # Rendered architecture diagram
-│       ├── mandatory_ii.md              # DevOps reflection task II
-│       ├── monitoring_repo_prompt.md
-│       └── technical_audit.md           # Technical audit report
+│       ├── mandatory-I/                 # Mandatory assignment I
+│       │   ├── BRANCHING_STRATEGY.md    # Git branching documentation
+│       │   ├── dependency_graph.dot     # System architecture (Graphviz source)
+│       │   ├── dependency_graph_picture.svg
+│       │   ├── openapi.yaml             # API specification
+│       │   └── technical_audit.md      # Technical audit report
+│       └── mandatory-II/               # Mandatory assignment II
+│           └── mandatory_ii.md         # DevOps reflection (branching, quality, monitoring, postmortem)
 ├── implementations/
 │   └── go/                              # Active Go implementation
 │       ├── Dockerfile

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Welcome to the **SyntaxDevopsSquad** main repository. This project is part of ou
 - **Security:** CSRF protection, middleware, and breach response tooling
 - **Database:** PostgreSQL with native full-text search
 - **Health Check:** `GET /health` endpoint for uptime monitoring and watchdog integration
-- **Weather Forecast:** `GET /weather` – city-based weather forecast via Open-Meteo API with in-memory cache (10 min TTL)
+- **Weather Forecast:** `GET /weather` - city-based weather forecast via Open-Meteo API with in-memory cache (10 min TTL)
 
 ### Team Members
 - **CodeByNajib** (NajibGPT)
@@ -47,7 +47,7 @@ Welcome to the **SyntaxDevopsSquad** main repository. This project is part of ou
 ### Infrastructure & DevOps
 - **Cloud Platforms:** Azure (app VM) + DigitalOcean (monitoring VM)
 - **Containerization:** Docker + Docker Compose (dev & prod)
-- **CI/CD:** GitHub Actions (`ci.yml`, `cd.yml`, `dependabot-auto-merge.yml`) — CI includes Hadolint (Dockerfile linting), CD includes Trivy (image vulnerability scanning). All actions SHA-pinned.
+- **CI/CD:** GitHub Actions (`ci.yml`, `cd.yml`, `dependabot-auto-merge.yml`) - CI includes Hadolint (Dockerfile linting), CD includes Trivy (image vulnerability scanning). All actions SHA-pinned.
 - **Infrastructure as Code:** Terraform (Azure VM, network, firewall, DigitalOcean droplet, Cloudflare DNS)
 - **Configuration Management:** Ansible (Docker, Nginx, fail2ban, UFW, swap, disk mount)
 - **DNS:** Cloudflare (automatic A-record update on deploy)

--- a/implementations/go/templates/layout.html
+++ b/implementations/go/templates/layout.html
@@ -15,7 +15,7 @@
             <h1><a id="nav-logo" href="/search">¿Who Knows?</a></h1>
             <div class="nav-right">
                 {{ if .User }}
-                    <a id="nav-logout" href="#" onclick="logoutUser(); return false;">Log out [{{ .User }}]</a>
+                    <a id="nav-logout" href="/logout">Log out [{{ .User }}]</a>
                 {{ else }}
                     <a id="nav-login" href="/login">Log in</a>
                     <a id="nav-register" href="/register">Register</a>
@@ -38,17 +38,6 @@
     </div>
 </div>
 <script>
-    function logoutUser() {
-        fetch('/api/logout')
-            .then(response => response.json())
-            .then(data => {
-                if (data.statusCode === 200) {
-                    sessionStorage.setItem('flash', 'You were logged out successfully.');
-                    window.location.href = '/';
-                }
-            });
-    }
-
     document.addEventListener("DOMContentLoaded", function() {
         const toastMsg = sessionStorage.getItem('flash');
         if (toastMsg) {

--- a/terraform/ansible/deploy.sh
+++ b/terraform/ansible/deploy.sh
@@ -21,7 +21,8 @@ echo ""
 echo "⚙️  Konfigurerer app VM med Ansible..."
 cd ansible
 perl -pi -e 's/\r//' inventory.ini
-ansible-playbook -i inventory.ini playbook.yml
+ansible-playbook -i inventory.ini playbook.yml \
+  -e "monitoring_ip=$MONITORING_IP"
 
 echo ""
 echo "📊 Konfigurerer monitoring VM med Ansible..."

--- a/terraform/ansible/grafana-provisioning/alerting/alert-rules.yml
+++ b/terraform/ansible/grafana-provisioning/alerting/alert-rules.yml
@@ -26,7 +26,7 @@ groups:
               to: 0
             datasourceUid: prometheus
             model:
-              expr: up{job="whoknows-app"}
+              expr: up{job="whoknows-go-backend"}
               instant: true
               refId: A
           - refId: B

--- a/terraform/ansible/monitoring-playbook.yml
+++ b/terraform/ansible/monitoring-playbook.yml
@@ -152,7 +152,7 @@
           scrape_configs:
             - job_name: 'whoknows-go-backend'
               static_configs:
-                - targets: ['{{ app_ip }}:8080']
+                - targets: ['{{ app_ip }}:80']
               metrics_path: '/metrics'
 
     # ─── Grafana provisioning (datasource + dashboards) ────────────────────────

--- a/terraform/ansible/playbook.yml
+++ b/terraform/ansible/playbook.yml
@@ -237,7 +237,16 @@
           server {
               listen 80;
               server_name syntax-reborndev.com www.syntax-reborndev.com;
-              return 301 https://$host$request_uri;
+
+              location /metrics {
+                  allow {{ monitoring_ip }};
+                  deny all;
+                  proxy_pass http://localhost:8080/metrics;
+              }
+
+              location / {
+                  return 301 https://$host$request_uri;
+              }
           }
         mode: "0644"
 


### PR DESCRIPTION
### Changes Made
- Fixed `App Down` alert rule: job name corrected from `whoknows-app` to `whoknows-go-backend`
- Updated README: fixed 7 outdated items (metrics port, dashboard count, branch strategy link, CI/CD tools, security, logging)

### Why Was It Necessary
The App Down alert was silently broken - it referenced a Prometheus job that does not exist, meaning the alert would never fire. The README had several factual inaccuracies accumulated from recent infrastructure changes (port 8080 binding, Prometheus scrape target, docs restructure).

## How to Test
1. Re-run monitoring playbook - verify App Down alert appears correctly in Grafana with `whoknows-go-backend` job
2. Stop the app container on the server - verify Discord alert fires within 2 minutes
3. Review README on GitHub - verify all links and descriptions are accurate

## Related Issues
N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [ ] CI/CD / Infrastructure
- [x] Documentation
- [ ] Breaking change

## Checklist
- [x] My code builds without errors
- [x] I have tested my changes locally
- [x] I have updated documentation if needed